### PR TITLE
Set the text field width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Make text field in the directory choosing widget always 15 characters wide
+
 ## [0.1.1] - 2019-05-23
 
 ### Fixed

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -90,6 +90,7 @@ public class MainPage extends JPanel {
         JPanel container = new JPanel();
         container.setLayout(new FlowLayout());
         JTextField field = new JTextField(current.toString());
+        field.setColumns(15);
         JButton button = new JButton("Browse");
         JFileChooser dialog = new JFileChooser(current.toFile());
         dialog.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);


### PR DESCRIPTION
The JTextField we use in the directory chooser (addPathSetting) can sometimes get a bit big and even cause the Browse button to be line-wrapped!

Let's limit it to 15 columns? (width can't be set in px, JTextField likes columns, ok)