### PR TITLE
Improve error handling

### DIFF
--- a/src/main/java/io/github/ImpactDevelopment/installer/Installer.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Installer.java
@@ -21,13 +21,11 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.github.ImpactDevelopment.installer.gui.AppIcon;
 import io.github.ImpactDevelopment.installer.gui.AppWindow;
-import org.apache.commons.io.IOUtils;
 
 import javax.swing.*;
 import java.text.SimpleDateFormat;
 
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.*;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Installer {
     public static final String project = "Impact";
@@ -61,16 +59,5 @@ public class Installer {
 
     public static String getTitle() {
         return project + " Installer";
-    }
-
-    public static boolean isMinecraftLauncherOpen() {
-        try {
-            if (getOS() == WINDOWS) {
-                return IOUtils.toString(new ProcessBuilder("tasklist", "/fi", "WINDOWTITLE eq Minecraft Launcher").start().getInputStream(), UTF_8).contains("MinecraftLauncher.exe");
-            }
-            return IOUtils.toString(new ProcessBuilder("ps", "-ef").start().getInputStream(), UTF_8).contains("Minecraft Launcher");
-        } catch (Throwable e) {
-            return false;
-        }
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/AppWindow.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/AppWindow.java
@@ -62,15 +62,13 @@ public class AppWindow extends JFrame {
         });
     }
 
-    public void exception(Throwable e) {
-        try {
-            throw e;
-        } catch (ExceptionInInitializerError ex) {
-            exception(ex.getCause());
-        } catch (Throwable th) {
-            th.printStackTrace();
-            JOptionPane.showMessageDialog(this, th + "\n" + th.getCause(), "Error", JOptionPane.ERROR_MESSAGE);
+    public void exception(Throwable th) {
+        th.printStackTrace();
+        String msg = th.getMessage() + "\n";
+        if (th.getCause() != null) {
+            msg += th.getCause();
         }
+        JOptionPane.showMessageDialog(this, msg, "Error", JOptionPane.ERROR_MESSAGE);
     }
 
     private void setContent(JPanel content) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -17,7 +17,6 @@
 
 package io.github.ImpactDevelopment.installer.gui.pages;
 
-import io.github.ImpactDevelopment.installer.Installer;
 import io.github.ImpactDevelopment.installer.gui.AppWindow;
 import io.github.ImpactDevelopment.installer.setting.ChoiceSetting;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
@@ -42,16 +41,6 @@ public class MainPage extends JPanel {
         JButton install = new JButton("Install");
         install.addActionListener((ActionEvent) -> {
             try {
-                if (Installer.isMinecraftLauncherOpen()) {
-                    int ret = JOptionPane.showOptionDialog(app, "Please close Minecraft and its launcher before continuing", "\uD83D\uDE09", JOptionPane.DEFAULT_OPTION, JOptionPane.INFORMATION_MESSAGE, null, null, null);
-                    if (ret == JOptionPane.CLOSED_OPTION) {
-                        JOptionPane.showMessageDialog(app, "ok i wont install it then", "\uD83D\uDE1B", JOptionPane.ERROR_MESSAGE);
-                        return;
-                    }
-                    if (Installer.isMinecraftLauncherOpen()) {
-                        return; // click the button again lol
-                    }
-                }
                 app.config.getSettingValue(InstallationModeSetting.INSTANCE).mode.apply(app.config).apply();
                 JOptionPane.showMessageDialog(app, "Impact has been successfully installed", "\uD83D\uDE0E", JOptionPane.INFORMATION_MESSAGE);
             } catch (Throwable e) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/libraries/LibraryBaritone.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/libraries/LibraryBaritone.java
@@ -17,9 +17,9 @@
 
 package io.github.ImpactDevelopment.installer.libraries;
 
-import io.github.ImpactDevelopment.installer.utils.GPG;
 import io.github.ImpactDevelopment.installer.github.Github;
 import io.github.ImpactDevelopment.installer.github.GithubRelease;
+import io.github.ImpactDevelopment.installer.utils.GPG;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +75,7 @@ public class LibraryBaritone implements ILibrary {
             String ourLine = Stream.of(checksums.split("\n")).filter(line -> line.endsWith(getReleasedJarName())).findFirst().get();
             return ourLine.substring(0, 40);
         } catch (Exception e) {
-            throw new RuntimeException(strippedVersion, e);
+            throw new RuntimeException("Error fetching " + strippedVersion, e);
         }
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/libraries/MavenResolver.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/libraries/MavenResolver.java
@@ -18,19 +18,23 @@
 package io.github.ImpactDevelopment.installer.libraries;
 
 import com.google.gson.reflect.TypeToken;
-import io.github.ImpactDevelopment.installer.utils.Fetcher;
 import io.github.ImpactDevelopment.installer.Installer;
+import io.github.ImpactDevelopment.installer.utils.Fetcher;
 
 import java.util.Map;
 
 public class MavenResolver {
-    private static final Map<String, String> MAVEN_MAP = getMavenMap();
+    private static Map<String, String> MAVEN_MAP = null;
 
     private static Map<String, String> getMavenMap() {
         return Installer.gson.fromJson(Fetcher.fetch("https://impactdevelopment.github.io/Resources/data/maven.refmap.json"), new TypeToken<Map<String, String>>() {}.getType());
     }
 
     public static String getURLBase(String mavenGroup) {
+        if (MAVEN_MAP == null) {
+            // don't do this in the class initializer, so that if it fails we don't have a broken class that can't be referenced in the future
+            MAVEN_MAP = getMavenMap();
+        }
         String ret = MAVEN_MAP.get(mavenGroup);
         if (ret == null) {
             throw new IllegalArgumentException("Can't get URL for maven group " + mavenGroup);

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/VanillaProfiles.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/VanillaProfiles.java
@@ -138,4 +138,8 @@ public class VanillaProfiles {
         byte[] bytes = Installer.gson.toJson(json).getBytes(StandardCharsets.UTF_8);
         Files.write(launcherProfiles, bytes);
     }
+
+    public static boolean checkDirectory(Path path) {
+        return Files.exists(path.resolve("launcher_profiles.json"));
+    }
 }


### PR DESCRIPTION
Fixes #33, fixes #14 

The changes to MavenResolver are because if there was no network connection it would cause an ExceptionInInitializerError while classloading, which is bad because you can't try again it would fail from then on. Now if you call it again, it actually tries again.