### PR TITLE
Have the EXE look for Mojang's JRE on 64bit Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Upcoming
+## [Unreleased]
+
+### Changed
+- The EXE now uses Mojang's JRE if installed (on 64bit Windows) before falling back to "normally" installed JREs and JDKs.
 
 ## [0.5.0] - 2019-07-13
 

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,11 @@ createExe {
     copyright = 'Copyright (C) Impact Developers'
     fileDescription = project.description
     version = textVersion = project.version
+
+    // Default to Mojang's JRE and fallback to JRE version search
+    bundledJrePath = '%PROGRAMFILES(X86)%/Minecraft Launcher/runtime/jre-x64'
+    bundledJreAsFallback = false
+    jreMinVersion = project.targetCompatibility
 }
 
 build.finalizedBy(createExe)


### PR DESCRIPTION
Use the Mojang JRE on 64bit to avoid having to look for a normally installed JRE/JDK. Since AFAIK we can only provide one bundled JRE path, we can't also specify a 32bit Mojang JRE path 😭 

I used `%PROGRAMFILES(X86)%` instead of `C:\Program Files (x86)` because I'm a good boy 😃 

It will still search for a JRE/JDK in the normal places if it can't find Mojang's JRE, but it won't look for a 32bit Mojang JRE.

<details><summary><strong>Output from <code>installer-0.5.0.exe --l4j-debug-all</code> (launch4j.log)</strong></summary>

```


## Run without Minecraft Launcher installed
## Note: falls back to JRE search and finds a 64bit JRE at C:\Program Files\Java\jdk-11.0.1\bin\javaw.exe

Version:	3.12
CmdLine:	C:\Users\leaf\Development\Impact-Installer\build\launch4j\installer-0.5.0.exe --l4j-debug-all
WOW64:		yes
Resource 10:	<NULL>
Resource 22:	<NULL>
Resource 101:	An error occurred while starting the application.
Resource 23:	<NULL>
Resource 8:	.
Working dir:	C:\Users\leaf\Development\Impact-Installer\build\launch4j\.
jreSearch()
Resource 32:	<NULL>
Resource 2:	1.8.0
Java min ver:	1.008.000
Resource 3:	<NULL>
Java max ver:	
bundledJreSearch()
Resource 29:	<NULL>
Resource 1:	%PROGRAMFILES(X86)%\Minecraft Launcher\runtime\jre-x64
Substitute:	PROGRAMFILES(X86) = C:\Program Files (x86)
Bundled JRE:	C:\Program Files (x86)\Minecraft Launcher\runtime\jre-x64
Check launcher:	C:\Program Files (x86)\Minecraft Launcher\runtime\jre-x64\bin\javaw.exe (not found)
installedJreSearch()
Resource 18:	1
findJavaHome()
Resource 30:	2
64-bit search:	SOFTWARE\JavaSoft\Java Runtime Environment...
Check:		SOFTWARE\JavaSoft\Java Runtime Environment\1.8
Check launcher:	C:\Program Files\Java\jre1.8.0_211\bin\javaw.exe (OK)
Match:		1.008.000
Check:		SOFTWARE\JavaSoft\Java Runtime Environment\1.8.0_201
Check launcher:	C:\Program Files\Java\jre1.8.0_201\bin\javaw.exe (OK)
Match:		1.008.000_201
Check:		SOFTWARE\JavaSoft\Java Runtime Environment\1.8.0_211
Check launcher:	C:\Program Files\Java\jre1.8.0_211\bin\javaw.exe (OK)
Match:		1.008.000_211
64-bit search:	SOFTWARE\JavaSoft\Java Development Kit...
Check:		SOFTWARE\JavaSoft\Java Development Kit\1.8
Ignore:		1.008.000
Check:		SOFTWARE\JavaSoft\Java Development Kit\1.8.0_192
Ignore:		1.008.000_192
Check:		SOFTWARE\JavaSoft\Java Development Kit\1.8.0_202
Ignore:		1.008.000_202
64-bit search:	SOFTWARE\JavaSoft\JRE...
64-bit search:	SOFTWARE\JavaSoft\JDK...
Check:		SOFTWARE\JavaSoft\JDK\11.0.1
Check launcher:	C:\Program Files\Java\jdk-11.0.1\bin\javaw.exe (OK)
Match:		1.011.000_001
Runtime used:	1.011.000_001 (64-bit)
Resource 19:	<NULL>
Resource 20:	32
Resource 25:	<NULL>
Resource 26:	<NULL>
Resource 27:	<NULL>
Resource 28:	<NULL>
Resource 12:	<NULL>
Resource 17:	true
Resource 14:	<NULL>
Resource 15:	io.github.ImpactDevelopment.installer.Installer
Main class:	io.github.ImpactDevelopment.installer.Installer
Resource 16:	lib\installer-0.5.0.jar
Add classpath:	lib\installer-0.5.0.jar
Resource 13:	<NULL>
Launcher:	C:\Program Files\Java\jdk-11.0.1\bin\javaw.exe
Launcher args:	-classpath "C:\Users\leaf\Development\Impact-Installer\build\launch4j\installer-0.5.0.exe;lib\installer-0.5.0.jar" io.github.ImpactDevelopment.installer.Installer
Args length:	162/32768 chars
Resource 4:	<NULL>
Resource 31:	<NULL>
Resource 11:	<NULL>
Exit code:	0


## Run with Minecraft Launcher installed
## Note: it finds C:\Program Files (x86)\Minecraft Launcher\runtime\jre-x64\bin\javaw.exe

Version:	3.12
CmdLine:	C:\Users\leaf\Development\Impact-Installer\build\launch4j\installer-0.5.0.exe --l4j-debug-all
WOW64:		yes
Resource 10:	<NULL>
Resource 22:	<NULL>
Resource 101:	An error occurred while starting the application.
Resource 23:	<NULL>
Resource 8:	.
Working dir:	C:\Users\leaf\Development\Impact-Installer\build\launch4j\.
jreSearch()
Resource 32:	<NULL>
Resource 2:	1.8.0
Java min ver:	1.008.000
Resource 3:	<NULL>
Java max ver:	
bundledJreSearch()
Resource 29:	<NULL>
Resource 1:	%PROGRAMFILES(X86)%\Minecraft Launcher\runtime\jre-x64
Substitute:	PROGRAMFILES(X86) = C:\Program Files (x86)
Bundled JRE:	C:\Program Files (x86)\Minecraft Launcher\runtime\jre-x64
Check launcher:	C:\Program Files (x86)\Minecraft Launcher\runtime\jre-x64\bin\javaw.exe (OK)
Resource 19:	<NULL>
Resource 20:	32
Resource 25:	<NULL>
Resource 26:	<NULL>
Resource 27:	<NULL>
Resource 28:	<NULL>
Resource 12:	<NULL>
Resource 17:	true
Resource 14:	<NULL>
Resource 15:	io.github.ImpactDevelopment.installer.Installer
Main class:	io.github.ImpactDevelopment.installer.Installer
Resource 16:	lib\installer-0.5.0.jar
Add classpath:	lib\installer-0.5.0.jar
Resource 13:	<NULL>
Launcher:	C:\Program Files (x86)\Minecraft Launcher\runtime\jre-x64\bin\javaw.exe
Launcher args:	-classpath "C:\Users\leaf\Development\Impact-Installer\build\launch4j\installer-0.5.0.exe;lib\installer-0.5.0.jar" io.github.ImpactDevelopment.installer.Installer
Args length:	162/32768 chars
Resource 4:	<NULL>
Resource 31:	<NULL>
Resource 11:	<NULL>
Exit code:	0

```

</details>