### PR TITLE
Actually install OptiFine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Reworked the way OptiFine is supported. Instead of searching for an installed OptiFine instance, the user provides us an OptiFine jar which we install ourselves.
+- Reworked the way OptiFine is supported. Instead of searching for an installed OptiFine instance, the user provides us with an OptiFine installer jar.
 
 ## [0.8.5] - 2020-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Reworked the way OptiFine is supported. Instead of searching for an installed OptiFine instance, the user provides us an OptiFine jar which we install ourselves.
 
 ## [0.8.5] - 2020-03-25
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/Args.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Args.java
@@ -66,7 +66,7 @@ public class Args {
     @Parameter(names = {"--mc-dir", "--minecraft-dir", "--minecraft-directory", "--mc-path"}, description = "Path to the Minecraft directory")
     public String mcPath;
 
-    @Parameter(names = {"--optifine", "--of"}, description = "OptiFine, in the format like 1.12.2_HD_U_E2")
+    @Parameter(names = {"--optifine", "--of"}, description = "Path to an OptiFine jar")
     public String optifine;
 
     @Parameter(names = {"--no-ga", "--no-analytics", "--dnt", "--no-tracky"}, description = "Disable Google Analytics")
@@ -144,7 +144,8 @@ public class Args {
             setImpactVersion(config, false, new ImpactVersionDisk(Paths.get(file)));
         }
         if (optifine != null) {
-            if (!config.setSettingValue(OptiFineSetting.INSTANCE, optifine)) {
+            config.setSettingValue(OptiFineSetting.INSTANCE, true);
+            if (!config.setSettingValue(OptiFineFileSetting.INSTANCE, Paths.get(optifine))) {
                 throw new IllegalArgumentException(optifine + " is not found");
             }
         }

--- a/src/main/java/io/github/ImpactDevelopment/installer/Args.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Args.java
@@ -144,7 +144,7 @@ public class Args {
             setImpactVersion(config, false, new ImpactVersionDisk(Paths.get(file)));
         }
         if (optifine != null) {
-            config.setSettingValue(OptiFineSetting.INSTANCE, true);
+            config.setSettingValue(OptiFineToggleSetting.INSTANCE, true);
             if (!config.setSettingValue(OptiFineFileSetting.INSTANCE, Paths.get(optifine))) {
                 throw new IllegalArgumentException(optifine + " is not found");
             }

--- a/src/main/java/io/github/ImpactDevelopment/installer/Args.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Args.java
@@ -127,7 +127,7 @@ public class Args {
                 setImpactVersion(config, true, version);
                 try {
                     System.out.println(config.execute());
-                } catch (IOException e) {
+                } catch (Throwable e) {
                     throw new RuntimeException(e);
                 }
             }

--- a/src/main/java/io/github/ImpactDevelopment/installer/Args.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Args.java
@@ -66,7 +66,7 @@ public class Args {
     @Parameter(names = {"--mc-dir", "--minecraft-dir", "--minecraft-directory", "--mc-path"}, description = "Path to the Minecraft directory")
     public String mcPath;
 
-    @Parameter(names = {"--optifine", "--of"}, description = "Path to an OptiFine jar")
+    @Parameter(names = {"--optifine", "--of"}, description = "Path to an OptiFine installer jar")
     public String optifine;
 
     @Parameter(names = {"--no-ga", "--no-analytics", "--dnt", "--no-tracky"}, description = "Disable Google Analytics")

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/AppWindow.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/AppWindow.java
@@ -50,7 +50,7 @@ public class AppWindow extends JFrame {
         setContentPane(wrapper);
         setContent(loadingScreen());
         setSize(690, 420);
-        setResizable(true);
+        setResizable(false);
         setLocationRelativeTo(null);// center on screen
         setVisible(true);
         AppIcon.setAppIcon(this);

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/AppWindow.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/AppWindow.java
@@ -50,7 +50,7 @@ public class AppWindow extends JFrame {
         setContentPane(wrapper);
         setContent(loadingScreen());
         setSize(690, 420);
-        setResizable(false);
+        setResizable(true);
         setLocationRelativeTo(null);// center on screen
         setVisible(true);
         AppIcon.setAppIcon(this);

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -27,6 +27,7 @@ import io.github.ImpactDevelopment.installer.setting.ChoiceSetting;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 import io.github.ImpactDevelopment.installer.setting.Setting;
 import io.github.ImpactDevelopment.installer.setting.settings.*;
+import io.github.ImpactDevelopment.installer.target.InstallationModeOptions;
 
 import javax.swing.*;
 import java.awt.*;
@@ -45,7 +46,9 @@ public class MainPage extends JPanel {
         addSetting(InstallationModeSetting.INSTANCE, "Install for", app);
         addSetting(MinecraftVersionSetting.INSTANCE, "Minecraft version", app);
         addSetting(ImpactVersionSetting.INSTANCE, "Impact version", app);
-        addOptifineSetting(app);
+        if (!app.config.getSettingValue(InstallationModeSetting.INSTANCE).equals(InstallationModeOptions.FORGE)) {
+            addOptifineSetting(app);
+        }
 
         JButton install = new JButton("Install");
         install.addActionListener((ActionEvent) -> {

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -54,7 +54,7 @@ public class MainPage extends JPanel {
                 switch (app.config.getSettingValue(InstallationModeSetting.INSTANCE)) {
                     case SHOWJSON:
                     case MULTIMC:
-                        if (app.config.getSettingValue(OptiFineSetting.INSTANCE)) {
+                        if (app.config.getSettingValue(OptiFineToggleSetting.INSTANCE)) {
                             // Special case if installing optifine in showJson mode
                             msg += "\nDo you want to install OptiFine's libs?";
                             if (JOptionPane.showConfirmDialog(app, msg, "\uD83D\uDE0E", YES_NO_OPTION, INFORMATION_MESSAGE) == YES_OPTION) {
@@ -98,7 +98,7 @@ public class MainPage extends JPanel {
     }
 
     private void addOptifineSetting(AppWindow app) {
-        OptiFineSetting setting = OptiFineSetting.INSTANCE;
+        OptiFineToggleSetting setting = OptiFineToggleSetting.INSTANCE;
         InstallationConfig config = app.config;
         Boolean val = config.getSettingValue(setting);
         if (val == null) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -36,6 +36,8 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static javax.swing.JOptionPane.*;
+
 public class MainPage extends JPanel {
     public MainPage(AppWindow app) {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -49,7 +51,22 @@ public class MainPage extends JPanel {
         install.addActionListener((ActionEvent) -> {
             try {
                 String msg = app.config.execute();
-                JOptionPane.showMessageDialog(app, msg, "\uD83D\uDE0E", JOptionPane.INFORMATION_MESSAGE);
+                switch (app.config.getSettingValue(InstallationModeSetting.INSTANCE)) {
+                    case SHOWJSON:
+                    case MULTIMC:
+                        if (app.config.getSettingValue(OptiFineSetting.INSTANCE)) {
+                            // Special case if installing optifine in showJson mode
+                            msg += "\nDo you want to install OptiFine's libs?";
+                            if (JOptionPane.showConfirmDialog(app, msg, "\uD83D\uDE0E", YES_NO_OPTION, INFORMATION_MESSAGE) == YES_OPTION) {
+                                msg = app.config.installOptifine();
+                            } else {
+                                // Only break the switch if no more msg to show, otherwise fallthrough
+                                break;
+                            }
+                        }
+                    default:
+                        JOptionPane.showMessageDialog(app, msg, "\uD83D\uDE0E", INFORMATION_MESSAGE);
+                }
             } catch (Throwable e) {
                 app.exception(e);
             }

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -27,7 +27,6 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.InvalidParameterException;
 import java.util.Enumeration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -173,10 +172,10 @@ public class OptiFine {
 
     // Get a maven path based on an artifact id.
     // Ignores any classifier since last I checked, so does the Minecraft Launcher
-    private Path pathFromID(String artifact) {
+    private Path pathFromID(String artifact) throws IllegalArgumentException {
         String[] parts = artifact.split(":");
         if (parts.length < 3) {
-            throw new InvalidParameterException("OptiFine.pathFromID expected an artifact id with at least three parts, got "+artifact);
+            throw new IllegalArgumentException("OptiFine.pathFromID expected an artifact id with at least three parts, got "+artifact);
         }
         String group = parts[0].replace(".", File.separator);
         String id = parts[1];

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -132,7 +132,7 @@ public class OptiFine {
     // Get the artifact id for OptiFine's custom launchwrapper, or null if upstreams's is ok.
     @Nullable
     public String getLaunchwrapperID() {
-        if (requiresCustomLaunchwrapper()) {
+        if (!launchwrapperEntry.isEmpty()) {
             Matcher match = LW_REGEX.matcher(launchwrapperEntry);
             if (match.matches()) {
                 return String.format("optifine:%s:%s", match.group(1), match.group(2));
@@ -141,13 +141,9 @@ public class OptiFine {
         return null;
     }
 
-    public boolean requiresCustomLaunchwrapper() {
-        return !launchwrapperEntry.isEmpty();
-    }
-
     // Extract the launchwrapper jar to the target libraries directory
     public void installCustomLaunchwrapper(Path libs) throws IOException {
-        if (requiresCustomLaunchwrapper()) {
+        if (getLaunchwrapperID() != null) {
             Path outputPath = libs.resolve(pathFromID(getLaunchwrapperID()));
             Files.createDirectories(outputPath.getParent());
             Files.deleteIfExists(outputPath);

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -201,7 +201,7 @@ public class OptiFine {
     private static Path pathFromID(String artifact) throws IllegalArgumentException {
         String[] parts = artifact.split(":");
         if (parts.length < 3) {
-            throw new IllegalArgumentException("OptiFine.pathFromID() expected an artifact id with at least three parts, got "+artifact);
+            throw new IllegalArgumentException("OptiFine.pathFromID() expected an artifact id with at least three parts, got " + artifact);
         }
         String group = parts[0].replace(".", File.separator);
         String id = parts[1];

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -51,7 +51,7 @@ public class OptiFine {
     private String transformer = "";
     private String launchwrapperEntry = "";
 
-    public OptiFine(Path jarPath) {
+    public OptiFine(Path jarPath) throws RuntimeException {
         this.jarPath = jarPath;
         try {
             try (ZipFile file = new ZipFile(jarPath.toFile())) {
@@ -95,7 +95,7 @@ public class OptiFine {
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException("Error processing OptiFine jar", e);
         }
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -32,6 +32,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -132,12 +133,7 @@ public class OptiFine {
         if (version.length <= 2) {
             throw new IllegalStateException("OptiFine version has too few elements");
         }
-        StringBuilder b = new StringBuilder();
-        for (int i = 2; i < version.length; i++) {
-            if (i > 2) b.append("_");
-            b.append(version[i]);
-        }
-        return b.toString();
+        return String.join("_", Arrays.asList(version).subList(2, version.length));
     }
 
     // Get the full version as used by maven

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -175,7 +175,7 @@ public class OptiFine {
     }
 
     // Install the patched optifine jar in the target libraries directory
-    private void installOptiFine(Path destination, Path vanilla) throws IOException, InvocationTargetException, IllegalAccessException {
+    protected void installOptiFine(Path destination, Path vanilla) throws IOException, InvocationTargetException, IllegalAccessException {
         Files.deleteIfExists(destination);
         Files.createDirectories(destination.getParent());
 
@@ -184,7 +184,7 @@ public class OptiFine {
     }
 
     // Extract the launchwrapper jar to the target libraries directory
-    private void installLaunchwrapper(Path destination) throws IOException {
+    protected void installLaunchwrapper(Path destination) throws IOException {
         String entry = String.format("launchwrapper-of-%s.jar", launchwrapperVersion);
         try (ZipFile file = new ZipFile(jarPath.toFile())) {
             try (InputStream input = file.getInputStream(file.getEntry(entry))) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -141,30 +141,34 @@ public class OptiFine {
         return null;
     }
 
-    // Extract the launchwrapper jar to the target libraries directory
-    public void installCustomLaunchwrapper(Path libs) throws IOException {
+    // Install optifine jar and launchwrapper (if required) to the target libraries directory
+    public void install(Path libs) throws IOException {
+        installOptiFine(libs.resolve(pathFromID(getOptiFineID())));
         if (getLaunchwrapperID() != null) {
-            Path outputPath = libs.resolve(pathFromID(getLaunchwrapperID()));
-            Files.createDirectories(outputPath.getParent());
-            Files.deleteIfExists(outputPath);
-            try (BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(outputPath.toFile()))) {
-                try (ZipFile file = new ZipFile(jarPath.toFile())) {
-                    InputStream input = file.getInputStream(file.getEntry(launchwrapperEntry));
-                    byte[] buffer = new byte[BUFFER_SIZE];
-                    int read = 0;
-                    while ((read = input.read(buffer)) != -1) {
-                        output.write(buffer, 0, read);
-                    }
-                }
-            }
+            installLaunchwrapper(libs.resolve(pathFromID(getLaunchwrapperID())));
         }
     }
 
     // Copy the optifine jar to the target libraries directory
-    public void installOptiFine(Path libs) throws IOException {
-        Path outputPath = libs.resolve(pathFromID(getOptiFineID()));
-        Files.createDirectories(outputPath.getParent());
-        Files.copy(jarPath, outputPath, REPLACE_EXISTING);
+    private void installOptiFine(Path destination) throws IOException {
+        Files.createDirectories(destination.getParent());
+        Files.copy(jarPath, destination, REPLACE_EXISTING);
+    }
+
+    // Extract the launchwrapper jar to the target libraries directory
+    private void installLaunchwrapper(Path destination) throws IOException {
+        Files.deleteIfExists(destination);
+        Files.createDirectories(destination.getParent());
+        try (BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(destination.toFile()))) {
+            try (ZipFile file = new ZipFile(jarPath.toFile())) {
+                InputStream input = file.getInputStream(file.getEntry(launchwrapperEntry));
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int read = 0;
+                while ((read = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, read);
+                }
+            }
+        }
     }
 
     // Get a maven path based on an artifact id.

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -43,15 +43,21 @@ public class OptiFine {
     private static final int BUFFER_SIZE = 4096;
 
     private final Path jarPath;
-
-    private String version = "";
-    private String mcVersion = "";
-    private String tweaker = "";
-    private String transformer = "";
-    private String launchwrapperEntry = "";
+    private final String version;
+    private final String mcVersion;
+    private final String tweaker;
+    private final String transformer;
+    private final String launchwrapperEntry;
 
     public OptiFine(Path jarPath) throws RuntimeException {
-        this.jarPath = jarPath;
+        // Set locals first while iterating the zip file, then set the final fields after
+        String version = "";
+        String mcVersion = "";
+        String tweaker = "";
+        String transformer = "";
+        String launchwrapperEntry = "";
+
+        // Iterate over the zip entries in the jar and extract any info we care about
         try {
             try (ZipFile file = new ZipFile(jarPath.toFile())) {
                 final Enumeration<? extends ZipEntry> entries = file.entries();
@@ -60,7 +66,9 @@ public class OptiFine {
                     if (LW_REGEX.matcher(entry.getName()).matches()) {
                         launchwrapperEntry = entry.getName();
                     }
-                    // This is probably the best way to get the version, since filenames can be easily changed
+                    // This is probably the best way to get the version, since filenames can be easily changed.
+                    // We set version and mcVersion to values from the first matching line in changelog.txt
+                    // (this should be the first line, but loop just in case).
                     if (entry.getName().equals("changelog.txt")) {
                         try (BufferedReader input = new BufferedReader(new InputStreamReader((file.getInputStream(entry))))) {
                             while (input.ready()) {
@@ -96,6 +104,14 @@ public class OptiFine {
         } catch (IOException e) {
             throw new RuntimeException("Error processing OptiFine jar", e);
         }
+
+        // Set the final fields
+        this.jarPath = jarPath;
+        this.version = version;
+        this.mcVersion = mcVersion;
+        this.tweaker = tweaker;
+        this.transformer = transformer;
+        this.launchwrapperEntry = launchwrapperEntry;
     }
 
     // Get the minecraft version this targets

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -40,7 +40,6 @@ public class OptiFine {
     private static final Pattern LW_REGEX = Pattern.compile("^(launchwrapper-of)-([0-9.]+)[.]jar$");
     private static final Pattern TWEAKER_REGEX = Pattern.compile("^TweakClass:\\s+(.+)$");
     private static final Pattern VERSION_REGEX = Pattern.compile("^OptiFine\\s+([^_]+)_(.+)$");
-    private static final int BUFFER_SIZE = 4096;
 
     private final Path jarPath;
     private final String version;
@@ -172,16 +171,10 @@ public class OptiFine {
 
     // Extract the launchwrapper jar to the target libraries directory
     private void installLaunchwrapper(Path destination) throws IOException {
-        Files.deleteIfExists(destination);
-        Files.createDirectories(destination.getParent());
-        try (BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(destination.toFile()))) {
-            try (ZipFile file = new ZipFile(jarPath.toFile())) {
-                InputStream input = file.getInputStream(file.getEntry(launchwrapperEntry));
-                byte[] buffer = new byte[BUFFER_SIZE];
-                int read = 0;
-                while ((read = input.read(buffer)) != -1) {
-                    output.write(buffer, 0, read);
-                }
+        try (ZipFile file = new ZipFile(jarPath.toFile())) {
+            try (InputStream input = file.getInputStream(file.getEntry(launchwrapperEntry))) {
+                Files.createDirectories(destination.getParent());
+                Files.copy(input, destination, REPLACE_EXISTING);
             }
         }
     }

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -179,6 +179,7 @@ public class OptiFine {
         Files.deleteIfExists(destination);
         Files.createDirectories(destination.getParent());
 
+        System.out.println("Installing OptiFine into " + destination.toString());
         // Static method so null instance
         patcherMethod.invoke(null, vanilla.toFile(), jarPath.toFile(), destination.toFile());
     }
@@ -188,6 +189,7 @@ public class OptiFine {
         String entry = String.format("launchwrapper-of-%s.jar", launchwrapperVersion);
         try (ZipFile file = new ZipFile(jarPath.toFile())) {
             try (InputStream input = file.getInputStream(file.getEntry(entry))) {
+                System.out.printf("Installing OptiFine's launchwrapper v%s into %s%n", launchwrapperVersion, destination.toString());
                 Files.createDirectories(destination.getParent());
                 Files.copy(input, destination, REPLACE_EXISTING);
             }

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFineExisting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFineExisting.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Impact Installer.
+ *
+ * Copyright (C) 2019  ImpactDevelopment and contributors
+ *
+ * See the CONTRIBUTORS.md file for a list of copyright holders
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package io.github.ImpactDevelopment.installer.optifine;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * This is a compatibility class that allows the installer to "upgrade" an existing install without needing the OptiFine installer jar
+ */
+@Deprecated
+public class OptiFineExisting extends OptiFine {
+
+    public OptiFineExisting(Path libraries, String version) throws RuntimeException {
+        // Surprisingly, passing the "mod" jar to super actually works, since it still includes the installer classes and the launchwrapper jar
+        super(libraries.resolve("optifine").resolve("OptiFine").resolve(version).resolve(String.format("OptiFine-%s.jar", version)));
+    }
+
+
+    @Override
+    protected void installOptiFine(Path destination, Path vanilla) throws IOException, InvocationTargetException, IllegalAccessException {
+        // No-op: this class was built from the installed OptiFine, "installing" it over itself is paradoxical
+    }
+
+    @Override
+    protected void installLaunchwrapper(Path destination) throws IOException {
+        // It can happen that this OptiFine wants its own launchwrapper but Impact was previously installed without it, so install it if it is missing
+        if (!Files.exists(destination)) {
+            super.installLaunchwrapper(destination);
+        }
+    }
+}

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/BooleanSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/BooleanSetting.java
@@ -20,15 +20,21 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package io.github.ImpactDevelopment.installer.setting.settings;
+package io.github.ImpactDevelopment.installer.setting;
 
-import io.github.ImpactDevelopment.installer.setting.BooleanSetting;
+public interface BooleanSetting extends Setting<Boolean> {
 
-public enum OptiFineSetting implements BooleanSetting {
-    INSTANCE;
+    default String displayName(InstallationConfig config, Boolean option) {
+        return option.toString();
+    }
 
     @Override
-    public String toString() {
-        return getClass().getSimpleName();
+    default Boolean getDefaultValue(InstallationConfig config) {
+        return false;
+    }
+
+    @Override
+    default boolean validSetting(InstallationConfig config, Boolean value) {
+        return true;
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/InstallationConfig.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/InstallationConfig.java
@@ -27,7 +27,6 @@ import io.github.ImpactDevelopment.installer.setting.settings.ImpactVersionSetti
 import io.github.ImpactDevelopment.installer.setting.settings.InstallationModeSetting;
 import io.github.ImpactDevelopment.installer.utils.Tracky;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -76,21 +75,21 @@ public class InstallationConfig {
         return !thisSettingReverted;
     }
 
-    public String execute() throws IOException {
+    public String execute() throws Throwable {
         String label = getSettingValue(ImpactVersionSetting.INSTANCE).getCombinedVersion();
         Tracky.event("installer", "install", label);
         String result;
         try {
             result = getSettingValue(InstallationModeSetting.INSTANCE).mode.apply(this).apply();
-        } catch (RuntimeException | IOException ex) {
+        } catch (Throwable t) {
             Tracky.event("installer", "error", label);
-            throw ex;
+            throw t;
         }
         Tracky.event("installer", "success", label);
         return result;
     }
 
-    public String installOptifine() throws IOException {
+    public String installOptifine() throws Throwable {
         return getSettingValue(InstallationModeSetting.INSTANCE).mode.apply(this).installOptifine();
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/InstallationConfig.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/InstallationConfig.java
@@ -89,4 +89,8 @@ public class InstallationConfig {
         Tracky.event("installer", "success", label);
         return result;
     }
+
+    public String installOptifine() throws IOException {
+        return getSettingValue(InstallationModeSetting.INSTANCE).mode.apply(this).installOptifine();
+    }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
@@ -24,16 +24,16 @@ package io.github.ImpactDevelopment.installer.setting.settings;
 
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 import io.github.ImpactDevelopment.installer.setting.Setting;
+import io.github.ImpactDevelopment.installer.utils.OperatingSystem;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public enum OptiFineFileSetting implements Setting<Path> {
     INSTANCE;
 
     @Override
     public Path getDefaultValue(InstallationConfig config) {
-            return Paths.get(System.getProperty("user.home"));
+            return OperatingSystem.getDownloads();
     }
 
     @Override

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
@@ -33,7 +33,7 @@ public enum OptiFineFileSetting implements Setting<Path> {
 
     @Override
     public Path getDefaultValue(InstallationConfig config) {
-            return OperatingSystem.getDownloads();
+        return OperatingSystem.getDownloads();
     }
 
     @Override

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
@@ -22,10 +22,25 @@
 
 package io.github.ImpactDevelopment.installer.setting.settings;
 
-import io.github.ImpactDevelopment.installer.setting.BooleanSetting;
+import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
+import io.github.ImpactDevelopment.installer.setting.Setting;
 
-public enum OptiFineSetting implements BooleanSetting {
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public enum OptiFineFileSetting implements Setting<Path> {
     INSTANCE;
+
+    @Override
+    public Path getDefaultValue(InstallationConfig config) {
+            return Paths.get(System.getProperty("user.home"));
+    }
+
+    @Override
+    public boolean validSetting(InstallationConfig config, Path value) {
+//        return value.getFileName().toString().toLowerCase().endsWith(".jar");
+        return true;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
@@ -22,10 +22,58 @@
 
 package io.github.ImpactDevelopment.installer.setting.settings;
 
-import io.github.ImpactDevelopment.installer.setting.BooleanSetting;
+import io.github.ImpactDevelopment.installer.setting.ChoiceSetting;
+import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
+import io.github.ImpactDevelopment.installer.target.InstallationModeOptions;
 
-public enum OptiFineSetting implements BooleanSetting {
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Specify an optifine version that is already installed. Will error if a version is selected that isn't installed in the official launcher
+ *
+ * @deprecated in favour of OptiFineFileSetting and OptiFineToggleSetting
+ */
+@Deprecated
+public enum OptiFineSetting implements ChoiceSetting<String> {
     INSTANCE;
+
+    public static final String NONE = "None";
+    public static final String MISSING = "Missing";
+
+    @Override
+    public List<String> getPossibleValues(InstallationConfig config) {
+        if (config.getSettingValue(InstallationModeSetting.INSTANCE) == InstallationModeOptions.FORGE || config.getSettingValue(MinecraftVersionSetting.INSTANCE).compareTo("1.15.2") > 0) {
+            return Collections.emptyList();
+        }
+        String minecraftVersion = config.getSettingValue(MinecraftVersionSetting.INSTANCE);
+        Path minecraftDirectory = config.getSettingValue(MinecraftDirectorySetting.INSTANCE);
+
+        List<String> result = new ArrayList<>();
+        try {
+            result.addAll(StreamSupport.stream(Files.newDirectoryStream(minecraftDirectory.resolve("libraries").resolve("optifine").resolve("OptiFine")).spliterator(), false)
+                    .map(Path::getFileName)
+                    .map(Object::toString)
+                    .filter(name -> name.startsWith(minecraftVersion + "_"))
+                    .sorted(Comparator.reverseOrder())
+                    .collect(Collectors.toList()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        if (result.isEmpty()) {
+            result.add(MISSING);
+        } else {
+            result.add(0, NONE);
+        }
+        return result;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineToggleSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineToggleSetting.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Impact Installer.
+ *
+ * Copyright (C) 2019  ImpactDevelopment and contributors
+ *
+ * See the CONTRIBUTORS.md file for a list of copyright holders
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package io.github.ImpactDevelopment.installer.setting.settings;
+
+import io.github.ImpactDevelopment.installer.setting.BooleanSetting;
+
+public enum OptiFineToggleSetting implements BooleanSetting {
+    INSTANCE;
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationMode.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationMode.java
@@ -25,9 +25,9 @@ package io.github.ImpactDevelopment.installer.target;
 import java.io.IOException;
 
 public interface InstallationMode {
-    String apply() throws IOException;  // not gonna lie this is me when i enter sicko mode
+    String apply() throws Throwable;  // not gonna lie this is me when i enter sicko mode
 
-    default String installOptifine() throws IOException {
+    default String installOptifine() throws Throwable {
         throw new IOException("Error: this installation mode doesn't support installing OptiFine");
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationMode.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationMode.java
@@ -26,4 +26,8 @@ import java.io.IOException;
 
 public interface InstallationMode {
     String apply() throws IOException;  // not gonna lie this is me when i enter sicko mode
+
+    default String installOptifine() throws IOException {
+        throw new IOException("Error: this installation mode doesn't support installing OptiFine");
+    }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -37,7 +37,7 @@ public class MultiMC implements InstallationMode {
     }
 
     @Override
-    public String apply() {
+    public String apply() throws Throwable {
         JsonObject toDisplay = new Vanilla(config).generateMultiMCJsonVersion();
         String data = Installer.gson.toJson(toDisplay);
         if (Installer.args.noGUI) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/ShowJSON.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/ShowJSON.java
@@ -28,6 +28,7 @@ import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 import io.github.ImpactDevelopment.installer.target.InstallationMode;
 
 import javax.swing.*;
+import java.io.IOException;
 
 public class ShowJSON implements InstallationMode {
     private final InstallationConfig config;
@@ -54,5 +55,10 @@ public class ShowJSON implements InstallationMode {
             frame.setVisible(true);
         });
         return "Here is the JSON for Vanilla " + toDisplay.get("id");
+    }
+
+    @Override
+    public String installOptifine() throws IOException {
+        return new Vanilla(config).installOptifine();
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/ShowJSON.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/ShowJSON.java
@@ -28,7 +28,6 @@ import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 import io.github.ImpactDevelopment.installer.target.InstallationMode;
 
 import javax.swing.*;
-import java.io.IOException;
 
 public class ShowJSON implements InstallationMode {
     private final InstallationConfig config;
@@ -38,7 +37,7 @@ public class ShowJSON implements InstallationMode {
     }
 
     @Override
-    public String apply() {
+    public String apply() throws Throwable {
         JsonObject toDisplay = new Vanilla(config).generateVanillaJsonVersion();
         String data = Installer.gson.toJson(toDisplay);
         if (Installer.args.noGUI) {
@@ -58,7 +57,7 @@ public class ShowJSON implements InstallationMode {
     }
 
     @Override
-    public String installOptifine() throws IOException {
+    public String installOptifine() throws Throwable {
         return new Vanilla(config).installOptifine();
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -61,15 +61,15 @@ public class Vanilla implements InstallationMode {
         Path mcDir = config.getSettingValue(MinecraftDirectorySetting.INSTANCE);
         this.config = config;
         this.version = config.getSettingValue(ImpactVersionSetting.INSTANCE).fetchContents();
-        this.vanillaJar = mcDir.resolve("versions").resolve(version.mcVersion).resolve(version.mcVersion+".jar");
+        this.vanillaJar = mcDir.resolve("versions").resolve(version.mcVersion).resolve(version.mcVersion + ".jar");
         this.optifine = config.getSettingValue(OptiFineToggleSetting.INSTANCE)
                 ? new OptiFine(config.getSettingValue(OptiFineFileSetting.INSTANCE))
                 : Optional.ofNullable(config.getSettingValue(OptiFineSetting.INSTANCE))
-                        .filter(of -> !of.equals(NONE))
-                        .filter(of -> !of.equals(MISSING))
-                        .map(of -> new OptiFineExisting(mcDir.resolve("libraries"), of))
-                        .orElse(null);
-        this.id = String.format("%s-%s_%s%s", version.mcVersion, version.name, version.version, optifine == null ? "" : "-OptiFine_"+optifine.getOptiFineVersion());
+                .filter(of -> !of.equals(NONE))
+                .filter(of -> !of.equals(MISSING))
+                .map(of -> new OptiFineExisting(mcDir.resolve("libraries"), of))
+                .orElse(null);
+        this.id = String.format("%s-%s_%s%s", version.mcVersion, version.name, version.version, optifine == null ? "" : "-OptiFine_" + optifine.getOptiFineVersion());
         if (optifine != null && !optifine.getMinecraftVersion().equals(version.mcVersion)) {
             throw new IllegalStateException(String.format("OptiFine %s is not compatible with Minecraft %s", optifine.getVersion(), version.mcVersion));
         }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.InvalidParameterException;
 
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.WINDOWS;
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.getOS;
@@ -63,7 +62,7 @@ public class Vanilla implements InstallationMode {
         this.id = String.format("%s-%s_%s%s", version.mcVersion, version.name, version.version, optifine == null ? "" : "-OptiFine_"+optifine.getOptiFineVersion());
 
         if (optifine != null && !optifine.getMinecraftVersion().equals(version.mcVersion)) {
-            throw new InvalidParameterException(String.format("OptiFine %s is not compatible with Minecraft %s", optifine.getVersion(), version.mcVersion));
+            throw new IllegalStateException(String.format("OptiFine %s is not compatible with Minecraft %s", optifine.getVersion(), version.mcVersion));
         }
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -160,6 +160,23 @@ public class Vanilla implements InstallationMode {
         return "Impact has been successfully installed";
     }
 
+    @Override
+    public String installOptifine() throws IOException {
+        if (optifine == null) {
+            throw new IOException("Error, no optifine specified");
+        }
+
+        Path libs = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("libraries");
+        System.out.println("Installing OptiFine into:");
+        System.out.println(libs.toString());
+
+        optifine.installOptiFine(libs);
+        if (optifine.requiresCustomLaunchwrapper()) {
+            optifine.installCustomLaunchwrapper(libs);
+        }
+        return "Installed OptiFine successfully";
+    }
+
     public void sanityCheck(boolean allowMinecraftToBeOpen) {
         checkDirectory();
         checkVersionInstalled();
@@ -176,6 +193,7 @@ public class Vanilla implements InstallationMode {
         sanityCheck(allowMinecraftToBeOpen);
         installVersionJson();
         installProfiles();
+        installOptifine();
     }
 
     private void checkDirectory() {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -59,15 +59,9 @@ public class Vanilla implements InstallationMode {
     public Vanilla(InstallationConfig config) throws RuntimeException {
         this.version = config.getSettingValue(ImpactVersionSetting.INSTANCE).fetchContents();
         this.optifine = config.getSettingValue(OptiFineSetting.INSTANCE) ? new OptiFine(config.getSettingValue(OptiFineFileSetting.INSTANCE)) : null;
+        this.vanillaJar = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("versions").resolve(version.mcVersion).resolve(version.mcVersion+".jar");
         this.config = config;
         this.id = String.format("%s-%s_%s%s", version.mcVersion, version.name, version.version, optifine == null ? "" : "-OptiFine_"+optifine.getOptiFineVersion());
-
-        // TODO consider downloading the jar from mojang ourselves?
-        //      or at least consider how to do this for multimc?
-        this.vanillaJar = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("versions").resolve(version.mcVersion).resolve(version.mcVersion+".jar");
-        if (optifine != null && !Files.isRegularFile(vanillaJar)) {
-            throw new IllegalStateException("If installing OptiFine, you must play Minecraft "+version.mcVersion+" at least once before continuing!");
-        }
 
         if (optifine != null && !optifine.getMinecraftVersion().equals(version.mcVersion)) {
             throw new IllegalStateException(String.format("OptiFine %s is not compatible with Minecraft %s", optifine.getVersion(), version.mcVersion));
@@ -209,9 +203,8 @@ public class Vanilla implements InstallationMode {
     }
 
     private void checkVersionInstalled() {
-        Path path = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("versions").resolve(version.mcVersion).resolve(version.mcVersion + ".jar");
-        if (!Files.exists(path)) {
-            throw new RuntimeException("Please install and run Vanilla " + version.mcVersion + " once as normal before continuing.", new FileNotFoundException(path.toString()));
+        if (!Files.exists(vanillaJar)) {
+            throw new RuntimeException("Please install and run Vanilla " + version.mcVersion + " once as normal before continuing.", new FileNotFoundException(vanillaJar.toString()));
         }
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -202,7 +202,9 @@ public class Vanilla implements InstallationMode {
         sanityCheck(allowMinecraftToBeOpen);
         installVersionJson();
         installProfiles();
-        installOptifine();
+        if (optifine != null) {
+            installOptifine();
+        }
     }
 
     private void checkDirectory() {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -180,7 +180,6 @@ public class Vanilla implements InstallationMode {
         }
 
         Path libs = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("libraries");
-        System.out.println("Installing OptiFine into " + libs.toString());
         optifine.install(libs, vanillaJar);
 
         return "Installed OptiFine successfully";

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.InvalidParameterException;
 
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.WINDOWS;
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.getOS;
@@ -55,11 +56,15 @@ public class Vanilla implements InstallationMode {
     private final InstallationConfig config;
     private final OptiFine optifine;
 
-    public Vanilla(InstallationConfig config) {
+    public Vanilla(InstallationConfig config) throws InvalidParameterException {
         this.version = config.getSettingValue(ImpactVersionSetting.INSTANCE).fetchContents();
         this.optifine = config.getSettingValue(OptiFineSetting.INSTANCE) ? new OptiFine(config.getSettingValue(OptiFineFileSetting.INSTANCE)) : null;
         this.config = config;
-        this.id = version.mcVersion + "-" + version.name + "_" + version.version + (optifine == null ? "" : "-OptiFine_"+optifine.getOptiFineVersion());
+        this.id = String.format("%s-%s_%s%s", version.mcVersion, version.name, version.version, optifine == null ? "" : "-OptiFine_"+optifine.getOptiFineVersion());
+
+        if (optifine != null && !optifine.getMinecraftVersion().equals(version.mcVersion)) {
+            throw new InvalidParameterException(String.format("OptiFine %s is not compatible with Minecraft %s", optifine.getVersion(), version.mcVersion));
+        }
     }
 
     public JsonObject generateVanillaJsonVersion() {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -136,7 +136,7 @@ public class Vanilla implements InstallationMode {
     private void populateLib(ILibrary lib, JsonArray libraries) {
         if (optifine != null && optifine.requiresCustomLaunchwrapper() && lib.getName().equals("net.minecraft:launchwrapper:1.12")) {
             JsonObject optiLaunchWrapper = new JsonObject();
-            optiLaunchWrapper.addProperty("name", optifine.getRequiredLaunchwrapper());
+            optiLaunchWrapper.addProperty("name", optifine.getLaunchwrapperID());
             libraries.add(optiLaunchWrapper);
             return;
         }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -168,15 +168,13 @@ public class Vanilla implements InstallationMode {
     @Override
     public String installOptifine() throws IOException {
         if (optifine == null) {
-            throw new IOException("Error, no optifine specified");
+            throw new IllegalStateException("No optifine specified, cannot install OptiFine");
         }
 
         Path libs = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("libraries");
-        System.out.println("Installing OptiFine into:");
-        System.out.println(libs.toString());
+        System.out.println("Installing OptiFine into "+libs.toString());
+        optifine.install(libs);
 
-        optifine.installOptiFine(libs);
-        optifine.installCustomLaunchwrapper(libs);
         return "Installed OptiFine successfully";
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -179,7 +179,7 @@ public class Vanilla implements InstallationMode {
         }
 
         Path libs = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("libraries");
-        System.out.println("Installing OptiFine into "+libs.toString());
+        System.out.println("Installing OptiFine into " + libs.toString());
         optifine.install(libs, vanillaJar);
 
         return "Installed OptiFine successfully";

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -56,7 +56,7 @@ public class Vanilla implements InstallationMode {
     private final InstallationConfig config;
     private final OptiFine optifine;
 
-    public Vanilla(InstallationConfig config) throws InvalidParameterException {
+    public Vanilla(InstallationConfig config) throws RuntimeException {
         this.version = config.getSettingValue(ImpactVersionSetting.INSTANCE).fetchContents();
         this.optifine = config.getSettingValue(OptiFineSetting.INSTANCE) ? new OptiFine(config.getSettingValue(OptiFineFileSetting.INSTANCE)) : null;
         this.config = config;

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -134,7 +134,7 @@ public class Vanilla implements InstallationMode {
     }
 
     private void populateLib(ILibrary lib, JsonArray libraries) {
-        if (optifine != null && optifine.requiresCustomLaunchwrapper() && lib.getName().equals("net.minecraft:launchwrapper:1.12")) {
+        if (optifine != null && optifine.getLaunchwrapperID() != null && lib.getName().equals("net.minecraft:launchwrapper:1.12")) {
             JsonObject optiLaunchWrapper = new JsonObject();
             optiLaunchWrapper.addProperty("name", optifine.getLaunchwrapperID());
             libraries.add(optiLaunchWrapper);
@@ -176,9 +176,7 @@ public class Vanilla implements InstallationMode {
         System.out.println(libs.toString());
 
         optifine.installOptiFine(libs);
-        if (optifine.requiresCustomLaunchwrapper()) {
-            optifine.installCustomLaunchwrapper(libs);
-        }
+        optifine.installCustomLaunchwrapper(libs);
         return "Installed OptiFine successfully";
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/utils/OperatingSystem.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/utils/OperatingSystem.java
@@ -22,6 +22,9 @@
 
 package io.github.ImpactDevelopment.installer.utils;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static java.util.Locale.ROOT;
 
 /**
@@ -47,5 +50,17 @@ public enum OperatingSystem {
             return LINUX;
         }
         return UNKNOWN;
+    }
+
+    public static Path getDownloads() {
+        if (getOS() == OperatingSystem.LINUX) {
+            String xdg = System.getenv("XDG_DOWNLOAD_DIR");
+            if (!xdg.isEmpty()) return Paths.get(xdg);
+        }
+        return getHome().resolve("Downloads");
+    }
+
+    public static Path getHome() {
+        return Paths.get(System.getProperty("user.home"));
     }
 }


### PR DESCRIPTION
Maily a precursor to fixing #91, but also simplifies the process of installing impact with optifine for the official launcher. Now instead of scanning the launcher for optifine, the user provides us an optifine jar which we install ourselves.

Need to double check I maintained the compatible optifine version check and that i fully removed redundant code (e.g. the scan for optifine in .minecraft) since i kinda rushed this and don't have time to check rn (lol)