### PR TITLE
Fully install a MultiMC instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added full support for MultiMC installation. The MultiMC mode now creates an instance just like the Vanilla mode creates a profile.
+
 ### Changed
 - Reworked the way OptiFine is supported. Instead of searching for an installed OptiFine instance, the user provides us with an OptiFine installer jar.
 - `--minecraft-directory`'s aliases changed; `--launcher-dir` and `--launcher-directory` were added and `--mc-path` was removed.

--- a/src/main/java/io/github/ImpactDevelopment/installer/Args.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Args.java
@@ -28,6 +28,7 @@ import io.github.ImpactDevelopment.installer.impact.ImpactVersionDisk;
 import io.github.ImpactDevelopment.installer.impact.ImpactVersionReleased;
 import io.github.ImpactDevelopment.installer.impact.ImpactVersions;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
+import io.github.ImpactDevelopment.installer.setting.Setting;
 import io.github.ImpactDevelopment.installer.setting.settings.*;
 import io.github.ImpactDevelopment.installer.target.InstallationModeOptions;
 
@@ -65,6 +66,9 @@ public class Args {
 
     @Parameter(names = {"--mc-dir", "--minecraft-dir", "--minecraft-directory", "--mc-path"}, description = "Path to the Minecraft directory")
     public String mcPath;
+
+    @Parameter(names = {"--mmc-dir", "--multimc-dir", "--multimc-directory", "--mmc-path"}, description = "Path to the MultiMC directory")
+    public String multimcPath;
 
     @Parameter(names = {"--optifine", "--of"}, description = "OptiFine, in the format like 1.12.2_HD_U_E2")
     public String optifine;
@@ -113,11 +117,10 @@ public class Args {
 
     public void apply(InstallationConfig config) {
         if (mcPath != null) {
-            Path path = Paths.get(mcPath);
-            if (!Files.isDirectory(path)) {
-                throw new IllegalStateException(path + " is not a directory");
-            }
-            config.setSettingValue(MinecraftDirectorySetting.INSTANCE, path);
+            setDirectory(config, MinecraftDirectorySetting.INSTANCE, mcPath);
+        }
+        if (multimcPath != null) {
+            setDirectory(config, MultiMCDirectorySetting.INSTANCE, multimcPath);
         }
         if (mode != null) {
             config.setSettingValue(InstallationModeSetting.INSTANCE, InstallationModeOptions.valueOf(mode.toUpperCase()));
@@ -148,6 +151,14 @@ public class Args {
                 throw new IllegalArgumentException(optifine + " is not found");
             }
         }
+    }
+
+    private void setDirectory(InstallationConfig config, Setting<Path> setting, String value) {
+        Path path = Paths.get(value);
+        if (!Files.isDirectory(path)) {
+            throw new IllegalStateException(path + " is not a directory");
+        }
+        config.setSettingValue(setting, path);
     }
 
     private void setImpactVersion(InstallationConfig config, boolean checkMcVersionValidityAgainstReleases, ImpactVersion version) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -27,6 +27,7 @@ import io.github.ImpactDevelopment.installer.setting.ChoiceSetting;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 import io.github.ImpactDevelopment.installer.setting.Setting;
 import io.github.ImpactDevelopment.installer.setting.settings.*;
+import io.github.ImpactDevelopment.installer.target.InstallationModeOptions;
 
 import javax.swing.*;
 import java.awt.*;
@@ -98,6 +99,10 @@ public class MainPage extends JPanel {
             container.add(new JLabel("OptiFine can sometimes cause visual glitches in Impact; only include it if you need it."));
         }
         add(container);
+
+        if (val.equals(InstallationModeOptions.MULTIMC)) {
+            addPathSetting(MultiMCDirectorySetting.INSTANCE, "MultiMC installation directory", app);
+        }
     }
 
     private void addPathSetting(Setting<Path> setting, String text, AppWindow app) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -63,7 +63,7 @@ public class MainPage extends JPanel {
                 // Special case if installing optifine in showJson mode
                 if (app.config.getSettingValue(InstallationModeSetting.INSTANCE).equals(SHOWJSON) && app.config.getSettingValue(OptiFineToggleSetting.INSTANCE)) {
                     msg += "\nDo you want to install OptiFine's libs?";
-                    if (JOptionPane.showConfirmDialog(app, msg, "\uD83D\uDE0E", YES_NO_OPTION, INFORMATION_MESSAGE) == YES_OPTION) {
+                    if (YES_OPTION == JOptionPane.showConfirmDialog(app, msg, "\uD83D\uDE0E", YES_NO_OPTION, INFORMATION_MESSAGE)) {
                         msg = app.config.installOptifine();
                     } else {
                         // Early return if no more msg dialogs needed

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -28,6 +28,7 @@ import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 import io.github.ImpactDevelopment.installer.setting.Setting;
 import io.github.ImpactDevelopment.installer.setting.settings.*;
 import io.github.ImpactDevelopment.installer.target.InstallationModeOptions;
+import io.github.ImpactDevelopment.installer.utils.OperatingSystem;
 
 import javax.swing.*;
 import java.awt.*;
@@ -38,6 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static io.github.ImpactDevelopment.installer.target.InstallationModeOptions.SHOWJSON;
+import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.OSX;
 import static javax.swing.JOptionPane.*;
 
 public class MainPage extends JPanel {
@@ -99,7 +101,11 @@ public class MainPage extends JPanel {
         add(container);
 
         if (val.equals(InstallationModeOptions.MULTIMC)) {
-            add(buildPathSetting(MultiMCDirectorySetting.INSTANCE, "MultiMC installation directory", JFileChooser.DIRECTORIES_ONLY, app));
+            String label = "MultiMC installation directory";
+            if (OperatingSystem.getOS() == OSX) {
+                label = "The MultiMC .app bundle";
+            }
+            add(buildPathSetting(MultiMCDirectorySetting.INSTANCE,  label, JFileChooser.DIRECTORIES_ONLY, app));
         }
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -103,7 +103,7 @@ public class MainPage extends JPanel {
         if (val.equals(InstallationModeOptions.MULTIMC)) {
             String label = "MultiMC installation directory";
             if (OperatingSystem.getOS() == OSX) {
-                label = "The MultiMC .app bundle";
+                label = "MultiMC application";
             }
             add(buildPathSetting(MultiMCDirectorySetting.INSTANCE,  label, JFileChooser.DIRECTORIES_ONLY, app));
         }

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static io.github.ImpactDevelopment.installer.target.InstallationModeOptions.SHOWJSON;
 import static javax.swing.JOptionPane.*;
 
 public class MainPage extends JPanel {
@@ -57,22 +58,17 @@ public class MainPage extends JPanel {
         install.addActionListener((ActionEvent) -> {
             try {
                 String msg = app.config.execute();
-                switch (app.config.getSettingValue(InstallationModeSetting.INSTANCE)) {
-                    case SHOWJSON:
-                    case MULTIMC:
-                        if (app.config.getSettingValue(OptiFineToggleSetting.INSTANCE)) {
-                            // Special case if installing optifine in showJson mode
-                            msg += "\nDo you want to install OptiFine's libs?";
-                            if (JOptionPane.showConfirmDialog(app, msg, "\uD83D\uDE0E", YES_NO_OPTION, INFORMATION_MESSAGE) == YES_OPTION) {
-                                msg = app.config.installOptifine();
-                            } else {
-                                // Only break the switch if no more msg to show, otherwise fallthrough
-                                break;
-                            }
-                        }
-                    default:
-                        JOptionPane.showMessageDialog(app, msg, "\uD83D\uDE0E", INFORMATION_MESSAGE);
+                // Special case if installing optifine in showJson mode
+                if (app.config.getSettingValue(InstallationModeSetting.INSTANCE).equals(SHOWJSON) && app.config.getSettingValue(OptiFineToggleSetting.INSTANCE)) {
+                    msg += "\nDo you want to install OptiFine's libs?";
+                    if (JOptionPane.showConfirmDialog(app, msg, "\uD83D\uDE0E", YES_NO_OPTION, INFORMATION_MESSAGE) == YES_OPTION) {
+                        msg = app.config.installOptifine();
+                    } else {
+                        // Early return if no more msg dialogs needed
+                        return;
+                    }
                 }
+                JOptionPane.showMessageDialog(app, msg, "\uD83D\uDE0E", INFORMATION_MESSAGE);
             } catch (Throwable e) {
                 app.exception(e);
             }

--- a/src/main/java/io/github/ImpactDevelopment/installer/impact/ImpactJsonVersion.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/impact/ImpactJsonVersion.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
  */
 public class ImpactJsonVersion {
     public String name; // will always be Impact :wink:
+    public String id = "net.impactclient.Impact";
     public String version;
     public String mcVersion;
     public String mainClass = "net.minecraft.launchwrapper.Launch";
@@ -46,6 +47,7 @@ public class ImpactJsonVersion {
 
     public void printInfo() {
         System.out.println(name);
+        System.out.println(id);
         System.out.println(version);
         System.out.println(mcVersion);
         System.out.println(mainClass);

--- a/src/main/java/io/github/ImpactDevelopment/installer/libraries/MavenResolver.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/libraries/MavenResolver.java
@@ -48,11 +48,21 @@ public class MavenResolver {
     }
 
     public static String getFullURL(String mavenName) {
-        String[] parts = mavenName.split(":");
-        return getURLBase(parts[0]) + partsToPath(parts);
+        return getURLBase(getGroup(mavenName)) + getPath(mavenName);
     }
 
-    public static String partsToPath(String[] parts) {
+    public static String getPath(String mavenName) {
+        String[] parts = mavenName.split(":");
         return parts[0].replace(".", "/") + "/" + parts[1] + "/" + parts[2] + "/" + parts[1] + "-" + parts[2] + ".jar";
+    }
+
+    public static String getFilename(String mavenName) {
+        String[] parts = mavenName.split(":");
+        return parts[1] + "-" + parts[2] + ".jar";
+    }
+
+    private static String getGroup(String mavenName) {
+        int index = mavenName.indexOf(":");
+        return index > -1 ? mavenName.substring(0, index) : "";
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/optifine/OptiFine.java
@@ -22,6 +22,8 @@
 
 package io.github.ImpactDevelopment.installer.optifine;
 
+import io.github.ImpactDevelopment.installer.libraries.MavenResolver;
+
 import javax.annotation.Nullable;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
@@ -163,14 +165,16 @@ public class OptiFine {
     }
 
     // Install optifine jar and launchwrapper (if required) to the target libraries directory
-    public void install(Path libs, Path vanilla) throws IOException {
+    public void install(Path libs, Path vanilla, boolean fullPath) throws IOException {
         try {
-            installOptiFine(libs.resolve(pathFromID(getOptiFineID())), vanilla);
+            Path path = Paths.get(fullPath ? MavenResolver.getPath(getOptiFineID()) : MavenResolver.getFilename(getOptiFineID()));
+            installOptiFine(libs.resolve(path), vanilla);
         } catch (InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException("Error calling OptiFine patcher method", e);
         }
         if (getLaunchwrapperID() != null) {
-            installLaunchwrapper(libs.resolve(pathFromID(getLaunchwrapperID())));
+            Path path = Paths.get(fullPath ? MavenResolver.getPath(getLaunchwrapperID()) : MavenResolver.getFilename(getLaunchwrapperID()));
+            installLaunchwrapper(libs.resolve(path));
         }
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/MultiMCDirectorySetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/MultiMCDirectorySetting.java
@@ -43,7 +43,7 @@ public enum MultiMCDirectorySetting implements Setting<Path> {
         // MultiMC is a portable app, so we can only guess its location.
         // On linux it can be installed via repos too, where it normally uses XDG_DATA_HOME, which is nice.
         if (OperatingSystem.getOS() == OperatingSystem.LINUX) {
-            return scanForMultiMC(data, home, downloads).orElse(data);
+            return scanForMultiMC(data, home, downloads).orElse(data.resolve("multimc"));
         }
         return scanForMultiMC(home, data, home.resolve("Games"), downloads).orElse(home);
     }

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/MultiMCDirectorySetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/MultiMCDirectorySetting.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Impact Installer.
+ *
+ * Copyright (C) 2019  ImpactDevelopment and contributors
+ *
+ * See the CONTRIBUTORS.md file for a list of copyright holders
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package io.github.ImpactDevelopment.installer.setting.settings;
+
+import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
+import io.github.ImpactDevelopment.installer.setting.Setting;
+import io.github.ImpactDevelopment.installer.utils.OperatingSystem;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+public enum MultiMCDirectorySetting implements Setting<Path> {
+    INSTANCE;
+
+    @Override
+    public Path getDefaultValue(InstallationConfig config) {
+        Path home = Paths.get(System.getProperty("user.home"));
+
+        // MultiMC is a portable app, so we can only guess its location.
+        // On linux it can be installed via repos too, where it normally uses XDG_DATA_HOME, which is nice.
+        switch (OperatingSystem.getOS()) {
+            case WINDOWS:
+                return scanForMultiMC(Paths.get("C:"), Paths.get(System.getenv("APPDATA")), home, home.resolve("Downloads"), home.resolve("Games")).orElse(home);
+            case OSX:
+                return scanForMultiMC(Paths.get("/"), home, home.resolve("Library").resolve("Application Support"), home.resolve("Downloads")).orElse(home);
+            default:
+                return scanForMultiMC(linuxDefault(), home, home.resolve("Downloads")).orElse(linuxDefault());
+        }
+    }
+
+    private static Optional<Path> scanForMultiMC(Path... locations) {
+        for (Path folder : locations) {
+            if (Files.isDirectory(folder)) {
+                // Just in case, check if the search location itself is multimc
+                if (isMultiMC(folder)) return Optional.of(folder);
+
+                // If not, check each of its children
+                try {
+                    Optional<Path> match = Files.walk(folder, 1)
+                            .filter(MultiMCDirectorySetting::isMultiMC)
+                            .findFirst();
+                    if (match.isPresent()) {
+                        return match;
+                    }
+                } catch (IOException ignored) { }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isMultiMC(Path path) {
+        // If multimc has been run in this location, even without completing setup, this file will exist
+        Path config = path.resolve("multimc.cfg");
+        return Files.isDirectory(path) && Files.isRegularFile(config);
+    }
+
+    private static Path linuxDefault() {
+        String xdg = System.getenv("XDG_DATA_HOME");
+        Path data = xdg.isEmpty()
+                ? Paths.get(System.getProperty("user.home")).resolve(".local").resolve("share")
+                : Paths.get(xdg);
+        return data.resolve("multimc");
+    }
+
+    @Override
+    public boolean validSetting(InstallationConfig config, Path value) {
+        // we are ALL minecraft paths on this blessed day
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
@@ -49,6 +49,7 @@ public enum OptiFineSetting implements ChoiceSetting<String> {
         }
         String minecraftVersion = config.getSettingValue(MinecraftVersionSetting.INSTANCE);
         Path minecraftDirectory = config.getSettingValue(MinecraftDirectorySetting.INSTANCE);
+        // TODO also look through multimc for installed optifine?
 
         List<String> result = new ArrayList<>();
         try {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationModeOptions.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationModeOptions.java
@@ -62,7 +62,7 @@ public enum InstallationModeOptions {
             case SHOWJSON:
                 return "Show Vanilla JSON";
             case MULTIMC:
-                return "Show MultiMC JSON";
+                return "MultiMC";
             case FORGE:
                 return "Forge";
             case VALIDATE:

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -85,7 +85,7 @@ public class MultiMC extends Vanilla {
     @Override
     public JsonObject generateJsonVersion() {
         JsonObject object = new JsonObject();
-        object.addProperty("fileID", "net.impactclient.Impact");
+        object.addProperty("fileID", version.id);
         object.addProperty("mainClass", version.mainClass);
         object.addProperty("mcVersion", version.mcVersion);
         object.addProperty("name", "Impact " + version.version);
@@ -117,8 +117,8 @@ public class MultiMC extends Vanilla {
         JsonObject vanilla = new JsonObject();
         JsonObject impact = new JsonObject();
 
-        impact.addProperty("uid", getId());
-        impact.addProperty("version", id);
+        impact.addProperty("uid", version.id);
+        impact.addProperty("version", getId());
         impact.addProperty("important", true);
         vanilla.addProperty("uid", "net.minecraft");
         vanilla.addProperty("version", version.mcVersion);

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -22,23 +22,22 @@
 
 package io.github.ImpactDevelopment.installer.target.targets;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.github.ImpactDevelopment.installer.Installer;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
-import io.github.ImpactDevelopment.installer.target.InstallationMode;
 
 import javax.swing.*;
 
-public class MultiMC implements InstallationMode {
-    private final InstallationConfig config;
+public class MultiMC extends Vanilla {
 
     public MultiMC(InstallationConfig config) {
-        this.config = config;
+        super(config);
     }
 
     @Override
     public String apply() {
-        JsonObject toDisplay = new Vanilla(config).generateMultiMCJsonVersion();
+        JsonObject toDisplay = generateJsonVersion();
         String data = Installer.gson.toJson(toDisplay);
         if (Installer.args.noGUI) {
             return data;
@@ -54,5 +53,25 @@ public class MultiMC implements InstallationMode {
             frame.setVisible(true);
         });
         return "Here is the JSON for MultiMC " + toDisplay.get("version");
+    }
+
+    @Override
+    public JsonObject generateJsonVersion() {
+        JsonObject object = new JsonObject();
+        object.addProperty("fileID", "net.impactclient.Impact");
+        object.addProperty("mainClass", version.mainClass);
+        object.addProperty("mcVersion", version.mcVersion);
+        object.addProperty("name", "Impact " + version.version);
+        object.addProperty("order", 10);
+        object.addProperty("version", id);
+        object.add("+tweakers", generateTweakers());
+        object.add("+libraries", generateLibraries());
+        return object;
+    }
+
+    private JsonArray generateTweakers() {
+        JsonArray arrayTweakers = new JsonArray();
+        version.tweakers.forEach(arrayTweakers::add);
+        return arrayTweakers;
     }
 }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -131,8 +131,8 @@ public class MultiMC extends Vanilla {
         JsonArray libraries = generateLibraries();
 
         // MultiMC will try to download libraries itself unless they are explicitly tagged as "local".
-        // I haven't checked if `downloads.artifacts.url: ""` works, but IMO just setting `MMC-hint: local` is a simpler
-        // and more idiomatic solution anyway.
+        // I haven't checked if `downloads.artifacts.url: ""` works, but IMO just setting `MMC-hint: local` is simpler
+        // and more idiomatic anyway.
         StreamSupport.stream(libraries.spliterator(), false)
                 .filter(lib -> {
                     try {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -27,14 +27,27 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.github.ImpactDevelopment.installer.Installer;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
+import io.github.ImpactDevelopment.installer.setting.settings.MultiMCDirectorySetting;
 
 import javax.swing.*;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.stream.StreamSupport;
 
 public class MultiMC extends Vanilla {
 
+    private final String instanceName;
+    private final String instanceID;
+    private final Path mmc;
+    private final Path instance;
+
     public MultiMC(InstallationConfig config) {
         super(config);
+
+        this.instanceName = version.name + " " + getStrippedVersion() + " for " + version.mcVersion + (optifine == null ? "" : " with OptiFine " + optifine.getOptiFineVersion());
+        this.instanceID = version.name + "-" + getStrippedVersion() + "-" + version.mcVersion + (optifine == null ? "" : "-OptiFine-" + optifine.getOptiFineVersion());
+        this.mmc = config.getSettingValue(MultiMCDirectorySetting.INSTANCE);
+        this.instance = mmc.resolve("instances").resolve(instanceID);
     }
 
     @Override
@@ -55,6 +68,16 @@ public class MultiMC extends Vanilla {
             frame.setVisible(true);
         });
         return "Here is the JSON for MultiMC " + toDisplay.get("version");
+    }
+
+    @Override
+    public String installOptifine() throws IOException {
+        if (optifine == null) {
+            throw new IllegalStateException("No optifine specified, cannot install OptiFine");
+        }
+
+        optifine.install(instance.resolve("libraries"), vanillaJar, false);
+        return "Installed OptiFine successfully";
     }
 
     @Override

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -65,7 +65,8 @@ public class MultiMC extends Vanilla {
                 System.err.println("WARNING: vanilla " + version.mcVersion + " jar not present in " + mmc.resolve("libraries") + " falling back to " + vanillaJar);
             } else {
                 if (optifine != null) {
-                    throw new IllegalStateException("OptiFine is required but unable to find a vanilla jar");
+                    // TODO consider just downloading the jar ourselves
+                    throw new IllegalStateException("OptiFine is required but unable to find a vanilla jar. Please run Minecraft " + version.mcVersion + " at least once.");
                 }
                 System.err.println("WARNING: vanilla " + version.mcVersion + " jar not present in MultiMC or the Official Launcher");
                 vanillaJar = null;
@@ -103,6 +104,9 @@ public class MultiMC extends Vanilla {
     public String installOptifine() throws IOException {
         if (optifine == null) {
             throw new IllegalStateException("No optifine specified, cannot install OptiFine");
+        }
+        if (vanillaJar == null) {
+            throw new IllegalStateException("No vanillaJar specified, cannot install OptiFine");
         }
 
         optifine.install(instance.resolve("libraries"), vanillaJar, false);

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -23,11 +23,13 @@
 package io.github.ImpactDevelopment.installer.target.targets;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.github.ImpactDevelopment.installer.Installer;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 
 import javax.swing.*;
+import java.util.stream.StreamSupport;
 
 public class MultiMC extends Vanilla {
 
@@ -65,7 +67,21 @@ public class MultiMC extends Vanilla {
         object.addProperty("order", 10);
         object.addProperty("version", id);
         object.add("+tweakers", generateTweakers());
-        object.add("+libraries", generateLibraries());
+        JsonArray libraries = generateLibraries();
+
+        // Append "MMC-hint": "local" to any optifine libraries
+        StreamSupport.stream(libraries.spliterator(), false)
+                .filter(lib -> {
+                    try {
+                        return lib.getAsJsonObject().getAsJsonPrimitive("name").getAsString().startsWith("optifine:");
+                    } catch (NullPointerException | ClassCastException | IllegalStateException ignored) {
+                        return false;
+                    }
+                })
+                .map(JsonElement::getAsJsonObject)
+                .forEach(lib -> lib.addProperty("MMC-hint", "local"));
+
+        object.add("+libraries", libraries);
         return object;
     }
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -117,9 +117,11 @@ public class MultiMC extends Vanilla {
         JsonObject vanilla = new JsonObject();
         JsonObject impact = new JsonObject();
 
+        // Setting `important: true` prevents users from "accidentally" editing the patcher json
         impact.addProperty("uid", version.id);
         impact.addProperty("version", getId());
         impact.addProperty("important", true);
+
         vanilla.addProperty("uid", "net.minecraft");
         vanilla.addProperty("version", version.mcVersion);
         vanilla.addProperty("important", true);

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -27,6 +27,7 @@ import io.github.ImpactDevelopment.installer.Installer;
 import io.github.ImpactDevelopment.installer.libraries.MavenResolver;
 import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
 import io.github.ImpactDevelopment.installer.setting.settings.MultiMCDirectorySetting;
+import io.github.ImpactDevelopment.installer.utils.OperatingSystem;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.StreamSupport;
 
+import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.OSX;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
@@ -54,7 +56,9 @@ public class MultiMC extends Vanilla {
 
         this.instanceName = version.name + " " + getStrippedVersion() + " for " + version.mcVersion + (optifine == null ? "" : " with OptiFine " + optifine.getOptiFineVersion());
         this.instanceID = version.name + "-" + getStrippedVersion() + "-" + version.mcVersion + (optifine == null ? "" : "-OptiFine-" + optifine.getOptiFineVersion());
-        this.mmc = config.getSettingValue(MultiMCDirectorySetting.INSTANCE);
+
+        Path mmcDirectory = config.getSettingValue(MultiMCDirectorySetting.INSTANCE);
+        this.mmc = OperatingSystem.getOS() == OSX ? mmcDirectory.resolve("Contents").resolve("MacOS") : mmcDirectory;
         this.instance = mmc.resolve("instances").resolve(instanceID);
 
         Path mmcVanillaJar = mmc.resolve("libraries").resolve(MavenResolver.getPath("com.mojang:minecraft:" + version.mcVersion + ":client"));

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -109,7 +109,7 @@ public class MultiMC extends Vanilla {
             throw new IllegalStateException("No vanillaJar specified, cannot install OptiFine");
         }
 
-        // Since MultiMC 0.6.3 "local" libraries must be installed in instance/libraries rather than the main libraries
+        // MultiMC 0.6.3 "local" libraries must be installed in instance/libraries rather than the main libraries
         // directory. Unlike global libs, instance libs don't expect a full maven style path, instead MMC expects the
         // artifact file to be in the root of the instance libraries directory.
         // See https://github.com/MultiMC/MultiMC5/blob/develop/changelog.md#multimc-063

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -109,6 +109,11 @@ public class MultiMC extends Vanilla {
             throw new IllegalStateException("No vanillaJar specified, cannot install OptiFine");
         }
 
+        // Since MultiMC 0.6.3 "local" libraries must be installed in instance/libraries rather than the main libraries
+        // directory. Unlike global libs, instance libs don't expect a full maven style path, instead MMC expects the
+        // artifact file to be in the root of the instance libraries directory.
+        // See https://github.com/MultiMC/MultiMC5/blob/develop/changelog.md#multimc-063
+        // and https://github.com/MultiMC/MultiMC5/wiki/JSON-Patches#libraries
         optifine.install(instance.resolve("libraries"), vanillaJar, false);
         return "Installed OptiFine successfully";
     }
@@ -125,7 +130,9 @@ public class MultiMC extends Vanilla {
         object.add("+tweakers", generateTweakers());
         JsonArray libraries = generateLibraries();
 
-        // Append "MMC-hint": "local" to any optifine libraries
+        // MultiMC will try to download libraries itself unless they are explicitly tagged as "local".
+        // I haven't checked if `downloads.artifacts.url: ""` works, but IMO just setting `MMC-hint: local` is a simpler
+        // and more idiomatic solution anyway.
         StreamSupport.stream(libraries.spliterator(), false)
                 .filter(lib -> {
                     try {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/MultiMC.java
@@ -41,7 +41,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class MultiMC extends Vanilla {
 
-    private static final URL ICON = ClassLoader.getSystemResource("icons/128.png");
+    private static final URL ICON = ClassLoader.getSystemResource("icons/256.png");
     private static final String ICON_KEY = "impact";
 
     private final String instanceName;

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/ShowJSON.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/ShowJSON.java
@@ -38,7 +38,7 @@ public class ShowJSON implements InstallationMode {
 
     @Override
     public String apply() {
-        JsonObject toDisplay = new Vanilla(config).generateVanillaJsonVersion();
+        JsonObject toDisplay = new Vanilla(config).generateJsonVersion();
         String data = Installer.gson.toJson(toDisplay);
         if (Installer.args.noGUI) {
             return data;

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -54,8 +54,8 @@ public class Vanilla implements InstallationMode {
     protected final String id;
     protected final ImpactJsonVersion version;
     protected final InstallationConfig config;
-    private final OptiFine optifine;
-    private final Path vanillaJar;
+    protected final OptiFine optifine;
+    protected final Path vanillaJar;
 
     public Vanilla(InstallationConfig config) throws RuntimeException {
         Path mcDir = config.getSettingValue(MinecraftDirectorySetting.INSTANCE);
@@ -218,13 +218,8 @@ public class Vanilla implements InstallationMode {
         VanillaProfiles profiles = new VanillaProfiles(config);
         System.out.println("Injecting impact version...");
 
-        // go from 4.7.0-beta to 4.7-beta
-        String strippedVersion = version.version.split("-")[0];
-        if (strippedVersion.indexOf('.') != strippedVersion.lastIndexOf('.')) {
-            strippedVersion = strippedVersion.substring(0, strippedVersion.lastIndexOf('.'));
-        }
 
-        profiles.addOrMutate(version.name + " " + strippedVersion + " for " + version.mcVersion, getId());
+        profiles.addOrMutate(version.name + " " + getStrippedVersion() + " for " + version.mcVersion, getId());
         System.out.println("Saving vanilla profiles");
         profiles.saveToDisk();
     }
@@ -238,6 +233,15 @@ public class Vanilla implements InstallationMode {
         } catch (Throwable e) {
             return false;
         }
+    }
+
+    public String getStrippedVersion() {
+        // go from 4.7.0-beta to 4.7-beta
+        String strippedVersion = version.version.split("-")[0];
+        if (strippedVersion.indexOf('.') != strippedVersion.lastIndexOf('.')) {
+            strippedVersion = strippedVersion.substring(0, strippedVersion.lastIndexOf('.'));
+        }
+        return strippedVersion;
     }
 
     public String getId() {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -142,7 +142,7 @@ public class Vanilla implements InstallationMode {
             {
                 JsonObject artifact = new JsonObject();
                 downloads.add("artifact", artifact);
-                artifact.addProperty("path", MavenResolver.partsToPath(lib.getName().split(":")));
+                artifact.addProperty("path", MavenResolver.getPath(lib.getName()));
                 artifact.addProperty("sha1", lib.getSHA1());
                 artifact.addProperty("size", lib.getSize());
                 artifact.addProperty("url", lib.getURL());
@@ -163,7 +163,7 @@ public class Vanilla implements InstallationMode {
         }
 
         Path libs = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("libraries");
-        optifine.install(libs, vanillaJar);
+        optifine.install(libs, vanillaJar, false);
 
         return "Installed OptiFine successfully";
     }

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -38,7 +38,6 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -211,7 +210,7 @@ public class Vanilla implements InstallationMode {
             }
         }
         System.out.println("Writing to " + directory.resolve(id + ".json"));
-        Files.write(directory.resolve(id + ".json"), Installer.gson.toJson(generateJsonVersion()).getBytes(StandardCharsets.UTF_8));
+        Files.write(directory.resolve(id + ".json"), Installer.gson.toJson(generateJsonVersion()).getBytes(UTF_8));
     }
 
     private void installProfiles() throws IOException {

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -55,7 +55,8 @@ public class Vanilla implements InstallationMode {
     protected final ImpactJsonVersion version;
     protected final InstallationConfig config;
     protected final OptiFine optifine;
-    protected final Path vanillaJar;
+
+    protected Path vanillaJar;
 
     public Vanilla(InstallationConfig config) throws RuntimeException {
         Path mcDir = config.getSettingValue(MinecraftDirectorySetting.INSTANCE);

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -163,7 +163,7 @@ public class Vanilla implements InstallationMode {
         }
 
         Path libs = config.getSettingValue(MinecraftDirectorySetting.INSTANCE).resolve("libraries");
-        optifine.install(libs, vanillaJar, false);
+        optifine.install(libs, vanillaJar, true);
 
         return "Installed OptiFine successfully";
     }


### PR DESCRIPTION
Finally got around to fully supporting MultiMC install. No more "follow 20 steps on the wiki and copy paste a bunch of stuff," instead simply click "install" and then double click the big shiny ![impact icon](https://raw.githubusercontent.com/ImpactDevelopment/Resources/master/textures/Icon_16.png) in MultiMC.

Works with OptiFine thanks to the work done in #92, but it does require the vanilla jar to be present in either multimc's or the official launcher's libs. I'd rather like to just bite the bullet and download the jar from mojang's version manifest but that can be discussed separately.

This PR closes #49 and fixes #91.