### PR TITLE
Fixing links in CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,10 +45,10 @@ You'll want to add your change in the `## [Upcoming]` section, since it will mos
 
 Finally, remember that Changelogs are for humans, not machines. You should be describing what changed, from a user's perspective, not how it was changed from a technical perspective (that is what commit messages are for).  
 
-[issues list]: /ImpactDevelopment/Installer/issues
-[new issue]: /ImpactDevelopment/Installer/issues/new
-[fork]: /ImpactDevelopment/Installer/fork
-[devenv]: /ImpactDevelopment/Installer#setting-up-a-development-environment
+[issues list]: /../../issues
+[new issue]: /../../issues/new
+[fork]: /../../fork
+[devenv]: /../..#setting-up-a-development-environment
 [contrib]: CONTRIBUTORS.md
 [documenting your changes]: #documenting-your-changes
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,10 +45,10 @@ You'll want to add your change in the `## [Upcoming]` section, since it will mos
 
 Finally, remember that Changelogs are for humans, not machines. You should be describing what changed, from a user's perspective, not how it was changed from a technical perspective (that is what commit messages are for).  
 
-[issues list]: /../../issues
-[new issue]: /../../issues/new
-[fork]: /../../fork
-[devenv]: /../..#setting-up-a-development-environment
+[issues list]: https://github.com/ImpactDevelopment/Installer/issues
+[new issue]: https://github.com/ImpactDevelopment/Installer/issues/new
+[fork]: https://github.com/ImpactDevelopment/Installer/fork
+[devenv]: README.md#setting-up-a-development-environment
 [contrib]: CONTRIBUTORS.md
 [documenting your changes]: #documenting-your-changes
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to the Installer
 
 ## I have a question
-Issues aren't intended for handling questions. You're much better off contacting us through one of these methods [Discord]()
+Issues aren't intended for handling questions. You're much better off contacting us through one of these methods [Discord][discord]
 
 ## I found a bug
 Before reporting a bug, please take the time to check if someone else has already. Search the [issues list] for keywords that might match your issue.
@@ -20,7 +20,7 @@ Please do your best to follow the guidance below regarding [documenting your cha
 
 Once that's done you can checkout a new branch, make your changes to it, publish it and open a Pull Request asking us to merge the changes in your branch.
 
-Please see  [Creating a Pull Request from a Fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). If you're brand new to git checkout [Try Git](http://try.github.io/) or one of these [awesome tutorials](https://gist.github.com/jaseemabid/1321592)
+Please see  [Creating a Pull Request from a Fork](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). If you're brand new to git checkout [Try Git](https://try.github.io/) or one of these [awesome tutorials](https://gist.github.com/jaseemabid/1321592)
 
 ### Documenting your changes
 
@@ -53,3 +53,4 @@ Finally, remember that Changelogs are for humans, not machines. You should be de
 [documenting your changes]: #documenting-your-changes
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [good commit message]: https://chris.beams.io/posts/git-commit/
+[discord]: https://impactclient.net/discord

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ You can now run or debug the installer with `Shift`+`F10` and `Shift`+`F9`.
 Please see [Contributing]
 
 [Impact]: https://impactdevelopment.github.io/
-[releases]: /ImpactDevelopment/Installer/releases
-[Contributing]: /ImpactDevelopment/Installer/blob/master/CONTRIBUTING.md
+[releases]: /../../releases
+[Contributing]: CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ You can now run or debug the installer with `Shift`+`F10` and `Shift`+`F9`.
 Please see [Contributing]
 
 [Impact]: https://impactdevelopment.github.io/
-[releases]: /../../releases
+[releases]: https://github.com/ImpactDevelopment/Installer/releases
 [Contributing]: CONTRIBUTING.md


### PR DESCRIPTION
Some of the Links in [CONTRIBUTING.md](https://github.com/ImpactDevelopment/Installer/blob/master/README.md) and [README.md](https://github.com/ImpactDevelopment/Installer/blob/master/CONTRIBUTING.md) were leading to nowhere.
And I added the Discord link to [https://impactclient.net/discord](https://impactclient.net/discord) which was missing.