### PR TITLE
Add a Save As button to Forge mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added full support for MultiMC installation. The MultiMC mode now creates an instance just like the Vanilla mode creates a profile.
+- Added a "Save As" dialog to the Forge installation mode and a matching CLI argument `--destination`. This replaces the previous "Install" button, but only for Forge mode.
 
 ### Changed
 - Reworked the way OptiFine is supported. Instead of searching for an installed OptiFine instance, the user provides us with an OptiFine installer jar.
 - `--minecraft-directory`'s aliases changed; `--launcher-dir` and `--launcher-directory` were added and `--mc-path` was removed.
+- In "Show Vanilla JSON" mode the "Install" button now says "Show JSON" instead.
 
 ## Removed
 - Minecraft Directory setting from the GUI. It is still present as a CLI option.

--- a/src/main/java/io/github/ImpactDevelopment/installer/Args.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Args.java
@@ -64,6 +64,9 @@ public class Args {
     @Parameter(names = {"--all"}, description = "Run on all Impact releases")
     public boolean all = false;
 
+    @Parameter(names = {"--out", "--destination", "--dest"}, description = "Where to output \"Save As\" style modes like \"Forge\".")
+    public String dest;
+
     @Parameter(names = {"--mc-dir", "--minecraft-dir", "--minecraft-directory", "--launcher-dir", "--launcher-directory"}, description = "Path to the Minecraft Launcher directory")
     public String mcPath;
 
@@ -116,12 +119,6 @@ public class Args {
     }
 
     public void apply(InstallationConfig config) {
-        if (mcPath != null) {
-            setDirectory(config, MinecraftDirectorySetting.INSTANCE, mcPath);
-        }
-        if (multimcPath != null) {
-            setDirectory(config, MultiMCDirectorySetting.INSTANCE, multimcPath);
-        }
         if (mode != null) {
             config.setSettingValue(InstallationModeSetting.INSTANCE, InstallationModeOptions.valueOf(mode.toUpperCase()));
         }
@@ -152,11 +149,20 @@ public class Args {
                 throw new IllegalArgumentException(optifine + " is not found");
             }
         }
+        if (mcPath != null) {
+            setPath(config, MinecraftDirectorySetting.INSTANCE, mcPath, true);
+        }
+        if (multimcPath != null) {
+            setPath(config, MultiMCDirectorySetting.INSTANCE, multimcPath, true);
+        }
+        if (dest != null) {
+            setPath(config, DestinationSetting.INSTANCE, dest, false);
+        }
     }
 
-    private void setDirectory(InstallationConfig config, Setting<Path> setting, String value) {
+    private void setPath(InstallationConfig config, Setting<Path> setting, String value, boolean mustBeDirectory) {
         Path path = Paths.get(value);
-        if (!Files.isDirectory(path)) {
+        if (mustBeDirectory && !Files.isDirectory(path)) {
             throw new IllegalStateException(path + " is not a directory");
         }
         config.setSettingValue(setting, path);

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/DestinationSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/DestinationSetting.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Impact Installer.
+ *
+ * Copyright (C) 2019  ImpactDevelopment and contributors
+ *
+ * See the CONTRIBUTORS.md file for a list of copyright holders
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package io.github.ImpactDevelopment.installer.setting.settings;
+
+import io.github.ImpactDevelopment.installer.impact.ImpactVersion;
+import io.github.ImpactDevelopment.installer.setting.InstallationConfig;
+import io.github.ImpactDevelopment.installer.setting.Setting;
+import io.github.ImpactDevelopment.installer.target.InstallationModeOptions;
+
+import java.nio.file.Path;
+
+public enum DestinationSetting implements Setting<Path> {
+    INSTANCE;
+
+    @Override
+    public Path getDefaultValue(InstallationConfig config) {
+        InstallationModeOptions mode = config.getSettingValue(InstallationModeSetting.INSTANCE);
+        switch (mode) {
+            case FORGE:
+            case FORGE_PLUS_LITELOADER:
+                Path minecraft = config.getSettingValue(MinecraftDirectorySetting.INSTANCE);
+                ImpactVersion version = config.getSettingValue(ImpactVersionSetting.INSTANCE);
+                return minecraft.resolve("mods").resolve(version.mcVersion).resolve("Impact" + "-" + version.getCombinedVersion() + ".jar");
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public boolean validSetting(InstallationConfig config, Path value) {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationModeOptions.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/InstallationModeOptions.java
@@ -29,19 +29,23 @@ import io.github.ImpactDevelopment.installer.target.targets.*;
 import java.util.function.Function;
 
 public enum InstallationModeOptions {
-    VANILLA(Vanilla::new, true),
-    FORGE(opt -> new Forge(opt, false), true),
-    FORGE_PLUS_LITELOADER(opt -> new Forge(opt, true), true),
-    VALIDATE(Validate::new, false),
-    MULTIMC(MultiMC::new, true),
-    SHOWJSON(ShowJSON::new, true);
+    VANILLA("Vanilla", "Install", true, Vanilla::new),
+    FORGE("Forge", "Save As", true, opt -> new Forge(opt, false)),
+    FORGE_PLUS_LITELOADER("Forge + Liteloader", "Save As", true, opt -> new Forge(opt, true)),
+    VALIDATE("Validate Vanilla version", "Validate", false, Validate::new),
+    MULTIMC("MultiMC", "Install", true, MultiMC::new),
+    SHOWJSON("Show Vanilla JSON", "Show JSON", true, ShowJSON::new);
 
-    InstallationModeOptions(Function<InstallationConfig, InstallationMode> mode, boolean showInGUI) {
+    InstallationModeOptions(String name, String buttonText, boolean showInGUI, Function<InstallationConfig, InstallationMode> mode) {
         this.mode = mode;
+        this.name = name;
+        this.buttonText = buttonText;
         this.showInGUI = showInGUI;
     }
 
     public final Function<InstallationConfig, InstallationMode> mode;
+    private final String name;
+    private final String buttonText;
     public final boolean showInGUI;
 
     public boolean supports(ImpactVersion impact) {
@@ -54,25 +58,12 @@ public enum InstallationModeOptions {
         }
     }
 
+    public String getButtonText() {
+        return buttonText;
+    }
+
     @Override
     public String toString() {
-        // incredibly based code
-        // this is oof NGL :eyes:
-        switch (this) {
-            case VANILLA:
-                return "Vanilla";
-            case SHOWJSON:
-                return "Show Vanilla JSON";
-            case MULTIMC:
-                return "MultiMC";
-            case FORGE:
-                return "Forge";
-            case FORGE_PLUS_LITELOADER:
-                return "Forge + Liteloader";
-            case VALIDATE:
-                return "Validate Vanilla version";
-            default:
-                return "Unknown";
-        }
+        return name;
     }
 }


### PR DESCRIPTION
Rather than assuming the user is using the official launcher and their Forge profile is using the default run directory, let's ask them where to save the jar.

We still set a sane default, of course.

Tried to design it in a way that future modes could use "Save As" too, if appropriate.

The Install button's text is now set by the `InstallationModeOptions` instance. The output of Forge mode (and anything else that ends up using Save-As mode) is set using `DestinationSetting` which can be set from the CLI using `--destination` or `--out`.

`DestinationSetting#getDefaultValue` controls whether the Save-As dialog is shown or not. If the setting is `null`, no dialog is shown. If the setting is non-null, then a dialog is shown and the setting is set to the result of the dialog.

I'm not sure if the logic in `DestinationSetting#getDefaultValue` should be moved to `InstallationModeOptions` or perhaps the selected `InstallationMode`. Thoughts on how to approach this?