### PR TITLE
Allow selecting installed OptiFine versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Already installed OptiFine versions installed in the Official Launcher can be used again, without requiring an OptiFine installer jar. 
 - Improved the GUI spacing and layout.
 - Improved the OptiFine download link using `JHyperlink` from the [SwingSet3 demo](https://mvnrepository.com/artifact/org.webswing/webswing-demo-swingset3).
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/Args.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/Args.java
@@ -73,7 +73,7 @@ public class Args {
     @Parameter(names = {"--mmc-dir", "--multimc-dir", "--multimc-directory", "--mmc-path"}, description = "Path to the MultiMC directory")
     public String multimcPath;
 
-    @Parameter(names = {"--optifine", "--of"}, description = "Path to an OptiFine installer jar")
+    @Parameter(names = {"--optifine", "--of"}, description = "Path to an OptiFine installer jar or the version of an already installed OptiFine")
     public String optifine;
 
     @Parameter(names = {"--no-ga", "--no-analytics", "--dnt", "--no-tracky"}, description = "Disable Google Analytics")
@@ -145,7 +145,13 @@ public class Args {
         }
         if (optifine != null) {
             config.setSettingValue(OptiFineToggleSetting.INSTANCE, true);
-            if (!config.setSettingValue(OptiFineFileSetting.INSTANCE, Paths.get(optifine))) {
+
+            // Use OptiFineSetting before falling back to OptiFineFileSetting
+            if (config.setSettingValue(OptiFineSetting.INSTANCE, optifine)) {
+                System.out.println("Using existing installed OptiFine version " + optifine);
+            } else if (config.setSettingValue(OptiFineFileSetting.INSTANCE, Paths.get(optifine))) {
+                System.out.println("Using OptiFine installer " + Paths.get(optifine).getFileName());
+            } else {
                 throw new IllegalArgumentException(optifine + " is not found");
             }
         }

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -225,6 +225,7 @@ public class MainPage extends JPanel {
                 case MISSING:
                 case CUSTOM:
                     grid.add(buildPathSetting(OptiFineFileSetting.INSTANCE, "OptiFine installer", JFileChooser.FILES_ONLY, app));
+                    break;
             }
 
             try {

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -35,7 +35,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -70,6 +69,7 @@ public class MainPage extends JPanel {
         this.add(settings, BorderLayout.PAGE_START);
 
         JButton install = new JButton(mode.getButtonText());
+        install.setEnabled(shouldInstallButtonBeEnabled(app.config));
         install.addActionListener((ActionEvent) -> {
             try {
                 Optional<Path> destination = Optional.ofNullable(app.config.getSettingValue(DestinationSetting.INSTANCE));
@@ -129,6 +129,17 @@ public class MainPage extends JPanel {
         JPanel installPanel = new JPanel(new FlowLayout());
         installPanel.add(install);
         this.add(installPanel, BorderLayout.PAGE_END);
+    }
+
+    private boolean shouldInstallButtonBeEnabled(InstallationConfig config) {
+        if (config.getSettingValue(OptiFineToggleSetting.INSTANCE)) {
+            switch (config.getSettingValue(OptiFineSetting.INSTANCE)) {
+                case MISSING:
+                case CUSTOM:
+                    return Files.isRegularFile(config.getSettingValue(OptiFineFileSetting.INSTANCE));
+            }
+        }
+        return true;
     }
 
     private <T> JPanel buildSetting(ChoiceSetting<T> setting, String text, AppWindow app) {

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -35,12 +35,15 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
+import static io.github.ImpactDevelopment.installer.setting.settings.OptiFineSetting.CUSTOM;
+import static io.github.ImpactDevelopment.installer.setting.settings.OptiFineSetting.MISSING;
 import static io.github.ImpactDevelopment.installer.target.InstallationModeOptions.MULTIMC;
 import static io.github.ImpactDevelopment.installer.target.InstallationModeOptions.SHOWJSON;
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.OSX;
@@ -203,7 +206,15 @@ public class MainPage extends JPanel {
             warning.add(new JLabel("<html><center>OptiFine can sometimes cause visual issues in Impact;<br>only include it if you need it!</center></html>"));
             grid.add(warning);
 
-            grid.add(buildPathSetting(OptiFineFileSetting.INSTANCE, "OptiFine jar", JFileChooser.FILES_ONLY, app));
+            String version = config.getSettingValue(OptiFineSetting.INSTANCE);
+            if (!version.equals(MISSING)) {
+                grid.add(buildSetting(OptiFineSetting.INSTANCE, "OptiFine version", app));
+            }
+            switch (version) {
+                case MISSING:
+                case CUSTOM:
+                    grid.add(buildPathSetting(OptiFineFileSetting.INSTANCE, "OptiFine installer", JFileChooser.FILES_ONLY, app));
+            }
 
             try {
                 FlowLayout layout = new FlowLayout();

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineFileSetting.java
@@ -28,6 +28,12 @@ import io.github.ImpactDevelopment.installer.utils.OperatingSystem;
 
 import java.nio.file.Path;
 
+/**
+ * The OptiFine installer to use for installing Impact with Optifine
+ *
+ * @see OptiFineToggleSetting
+ * @see OptiFineSetting
+ */
 public enum OptiFineFileSetting implements Setting<Path> {
     INSTANCE;
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
@@ -37,11 +37,12 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
- * Specify an optifine version that is already installed. Will error if a version is selected that isn't installed in the official launcher
+ * Specify an OptiFine version that is already installed.
+ * Will error if a version is selected that isn't installed in the official launcher
  *
- * @deprecated in favour of OptiFineFileSetting and OptiFineToggleSetting
+ * @see OptiFineToggleSetting
+ * @see OptiFineFileSetting
  */
-@Deprecated
 public enum OptiFineSetting implements ChoiceSetting<String> {
     INSTANCE;
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineSetting.java
@@ -46,8 +46,8 @@ import java.util.stream.StreamSupport;
 public enum OptiFineSetting implements ChoiceSetting<String> {
     INSTANCE;
 
-    public static final String NONE = "None";
     public static final String MISSING = "Missing";
+    public static final String CUSTOM = "Custom";
 
     @Override
     public List<String> getPossibleValues(InstallationConfig config) {
@@ -72,7 +72,7 @@ public enum OptiFineSetting implements ChoiceSetting<String> {
         if (result.isEmpty()) {
             result.add(MISSING);
         } else {
-            result.add(0, NONE);
+            result.add(CUSTOM);
         }
         return result;
     }

--- a/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineToggleSetting.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/setting/settings/OptiFineToggleSetting.java
@@ -24,6 +24,11 @@ package io.github.ImpactDevelopment.installer.setting.settings;
 
 import io.github.ImpactDevelopment.installer.setting.BooleanSetting;
 
+/**
+ * Controls whether OptiFine will be installed or not.
+ *
+ * The actual installer or version should be set in {@link OptiFineFileSetting} or {@link OptiFineSetting} respectively.
+ */
 public enum OptiFineToggleSetting implements BooleanSetting {
     INSTANCE;
 

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -245,9 +245,13 @@ public class Vanilla implements InstallationMode {
                 case MISSING:
                 case CUSTOM:
                     Path installer = config.getSettingValue(OptiFineFileSetting.INSTANCE);
-                    if (Files.isRegularFile(installer) && Files.isReadable(installer)) {
-                        return new OptiFine(installer);
+                    if (!Files.isRegularFile(installer)) {
+                        throw new IllegalArgumentException("Selected installer is not a regular file " + installer.getFileName());
                     }
+                    if (!Files.isReadable(installer)) {
+                        throw new IllegalArgumentException("Cannot read file " + installer.getFileName());
+                    }
+                    return new OptiFine(installer);
                 default:
                     Path launcher = config.getSettingValue(MinecraftDirectorySetting.INSTANCE);
                     String version = config.getSettingValue(OptiFineSetting.INSTANCE);

--- a/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/target/targets/Vanilla.java
@@ -42,8 +42,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static io.github.ImpactDevelopment.installer.setting.settings.OptiFineSetting.CUSTOM;
 import static io.github.ImpactDevelopment.installer.setting.settings.OptiFineSetting.MISSING;
-import static io.github.ImpactDevelopment.installer.setting.settings.OptiFineSetting.NONE;
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.WINDOWS;
 import static io.github.ImpactDevelopment.installer.utils.OperatingSystem.getOS;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -243,7 +243,7 @@ public class Vanilla implements InstallationMode {
         if (config.getSettingValue(OptiFineToggleSetting.INSTANCE)) {
             switch (config.getSettingValue(OptiFineSetting.INSTANCE)) {
                 case MISSING:
-                case NONE:
+                case CUSTOM:
                     Path installer = config.getSettingValue(OptiFineFileSetting.INSTANCE);
                     if (Files.isRegularFile(installer) && Files.isReadable(installer)) {
                         return new OptiFine(installer);


### PR DESCRIPTION
Feedback on 0.9 suggested that removing the ability to install _Impact for OptiFine_ against an _already installed_ OptiFine (without providing that OptiFine's installer jar) was a step backwards.

This PR adds back the `OptiFine Version` drop down, replacing the `None` option with 0.9's `OptiFineToggleSetting` and adding a `Custom` option in order to access 0.9's `OptiFineFileSetting`.

Further feedback suggested disabling the Install button when no OptiFine file has been selected.

This has a **_minor_ breaking change** to the API used by Impact: Impact will now need to set `OptiFineToggleSetting` to true in addition to setting `OptiFineSetting`.

![](https://cdn.discordapp.com/attachments/308653317834145802/716298198326575134/unknown.png)