### PR TITLE
Potential fix for the null settings issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Error building setting for null value when changing settings in certain orders
+
 ## [0.9.1] - 2020-06-07
 
 ### Changed

--- a/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
+++ b/src/main/java/io/github/ImpactDevelopment/installer/gui/pages/MainPage.java
@@ -31,6 +31,7 @@ import io.github.ImpactDevelopment.installer.setting.settings.*;
 import io.github.ImpactDevelopment.installer.target.InstallationModeOptions;
 import io.github.ImpactDevelopment.installer.utils.OperatingSystem;
 
+import javax.annotation.Nullable;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
@@ -56,13 +57,13 @@ public class MainPage extends JPanel {
         JPanel settings = new JPanel();
         settings.setLayout(new BoxLayout(settings, BoxLayout.Y_AXIS));
 
-        settings.add(buildSetting(InstallationModeSetting.INSTANCE, "Install for", app));
+        Optional.ofNullable(buildSetting(InstallationModeSetting.INSTANCE, "Install for", app)).ifPresent(settings::add);
         if (mode == MULTIMC) settings.add(buildMultiMCSetting(app));
-        settings.add(buildSetting(MinecraftVersionSetting.INSTANCE, "Minecraft version", app));
-        settings.add(buildSetting(ImpactVersionSetting.INSTANCE, "Impact version", app));
+        Optional.ofNullable(buildSetting(MinecraftVersionSetting.INSTANCE, "Minecraft version", app)).ifPresent(settings::add);
+        Optional.ofNullable(buildSetting(ImpactVersionSetting.INSTANCE, "Impact version", app)).ifPresent(settings::add);
         switch (mode) {
             case FORGE: case FORGE_PLUS_LITELOADER: break;
-            default: settings.add(buildOptiFineSetting(app));
+            default: Optional.ofNullable(buildOptiFineSetting(app)).ifPresent(settings::add);
         }
 
         // Add the settings to the top of the window
@@ -142,10 +143,12 @@ public class MainPage extends JPanel {
         return true;
     }
 
+    @Nullable
     private <T> JPanel buildSetting(ChoiceSetting<T> setting, String text, AppWindow app) {
         T val = app.config.getSettingValue(setting);
         if (val == null) {
-            throw new IllegalStateException("Cannot build setting for null value of " + setting.getClass().getSimpleName());
+            System.err.println("Cannot build setting for null value of " + setting.getClass().getSimpleName());
+            return null;
         }
 
         InstallationConfig config = app.config;
@@ -172,12 +175,14 @@ public class MainPage extends JPanel {
         return buildPathSetting(MultiMCDirectorySetting.INSTANCE,  label, JFileChooser.DIRECTORIES_ONLY, app);
     }
 
+    @Nullable
     private JPanel buildOptiFineSetting(AppWindow app) {
         OptiFineToggleSetting setting = OptiFineToggleSetting.INSTANCE;
         InstallationConfig config = app.config;
         Boolean usingOptiFine = config.getSettingValue(setting);
         if (usingOptiFine == null) {
-            throw new IllegalStateException("Cannot build setting for null value of " + setting.getClass().getSimpleName());
+            System.err.println("Cannot build setting for null value of " + setting.getClass().getSimpleName());
+            return null;
         }
 
         JPanel grid = new JPanel();


### PR DESCRIPTION
When going from Vanilla + 1.15.2 to Forge, the version becomes blank, leading to other settings becoming null. This was revealed by some exceptions I added in 0.9.1.

This PR removes those exceptions (replacing them with log messages and nullable methods) but it may be better to fix the **underlying issue** instead:

![image](https://user-images.githubusercontent.com/23565638/83995846-67140880-a952-11ea-8f0e-8e1d0cb105fc.png)
